### PR TITLE
Json schema update

### DIFF
--- a/ReflectorNet.Tests/BaseTest.cs
+++ b/ReflectorNet.Tests/BaseTest.cs
@@ -1,0 +1,14 @@
+﻿using Xunit.Abstractions;
+
+namespace ReflectorNet.Tests
+{
+    public class BaseTest
+    {
+        protected readonly ITestOutputHelper _output;
+
+        public BaseTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+    }
+}

--- a/ReflectorNet.Tests/JsonSchemaTest.cs
+++ b/ReflectorNet.Tests/JsonSchemaTest.cs
@@ -1,0 +1,27 @@
+﻿using com.IvanMurzak.ReflectorNet.Model;
+using com.IvanMurzak.ReflectorNet.Utils;
+using Xunit.Abstractions;
+
+namespace ReflectorNet.Tests
+{
+    public class JsonSchemaTest : BaseTest
+    {
+        public JsonSchemaTest(ITestOutputHelper output) : base(output) { }
+
+        [Fact]
+        public void SerializedMemberList()
+        {
+            var methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.SerializedMemberList_ReturnString))!;
+            var schema = JsonUtils.GetArgumentsSchema(methodInfo, justRef: false)!;
+            _output.WriteLine(schema.ToString());
+            Assert.NotNull(schema);
+            Assert.NotNull(schema[JsonUtils.SchemaDefs]);
+
+            var defines = schema[JsonUtils.SchemaDefs]?.AsObject();
+            Assert.NotNull(defines);
+
+            var targetSchema = defines[typeof(SerializedMemberList).FullName!];
+            Assert.NotNull(targetSchema);
+        }
+    }
+}

--- a/ReflectorNet.Tests/JsonSchemaTest.cs
+++ b/ReflectorNet.Tests/JsonSchemaTest.cs
@@ -13,7 +13,9 @@ namespace ReflectorNet.Tests
         {
             var methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.SerializedMemberList_ReturnString))!;
             var schema = JsonUtils.GetArgumentsSchema(methodInfo, justRef: false)!;
+
             _output.WriteLine(schema.ToString());
+
             Assert.NotNull(schema);
             Assert.NotNull(schema[JsonUtils.SchemaDefs]);
 

--- a/ReflectorNet.Tests/ReflectorTests.cs
+++ b/ReflectorNet.Tests/ReflectorTests.cs
@@ -1,14 +1,14 @@
-﻿using System;
-using System.Linq;
-using System.Reflection;
+﻿using System.Linq;
 using com.IvanMurzak.ReflectorNet.Model;
 using com.IvanMurzak.ReflectorNet;
-using Xunit;
+using Xunit.Abstractions;
 
 namespace ReflectorNet.Tests
 {
-    public class ReflectorTests
+    public class ReflectorTests : BaseTest
     {
+        public ReflectorTests(ITestOutputHelper output) : base(output) { }
+
         [Fact]
         public void FindMethod_WithKnownMethod_ShouldReturnMethod()
         {

--- a/ReflectorNet.Tests/ReflectorTests.cs
+++ b/ReflectorNet.Tests/ReflectorTests.cs
@@ -2,6 +2,7 @@
 using com.IvanMurzak.ReflectorNet.Model;
 using com.IvanMurzak.ReflectorNet;
 using Xunit.Abstractions;
+using com.IvanMurzak.ReflectorNet.Utils;
 
 namespace ReflectorNet.Tests
 {
@@ -29,6 +30,8 @@ namespace ReflectorNet.Tests
                 methodNameMatchLevel: 6
             ).ToList();
 
+            _output.WriteLine(JsonUtils.Serialize(foundMethods));
+
             // Assert
             Assert.Single(foundMethods);
             Assert.Equal(nameof(TestClass.NoParameters_ReturnBool), foundMethods[0].Name);
@@ -54,6 +57,8 @@ namespace ReflectorNet.Tests
                 typeNameMatchLevel: 6,
                 methodNameMatchLevel: 2 // Lower level to match partial names
             ).ToList();
+
+            _output.WriteLine(JsonUtils.Serialize(foundMethods));
 
             // Assert
             Assert.Contains(foundMethods, m => m.Name == nameof(TestClass.NoParameters_ReturnBool));

--- a/ReflectorNet.Tests/TestClass.cs
+++ b/ReflectorNet.Tests/TestClass.cs
@@ -1,7 +1,13 @@
+using System.ComponentModel;
+using com.IvanMurzak.ReflectorNet.Model;
+
 namespace ReflectorNet.Tests
 {
     public class TestClass
     {
+        public const string CustomDescriptionA = "CustomDescriptionA";
+        public const string CustomDescriptionB = "CustomDescriptionB";
+
         public void NoParameters_ReturnVoid()
         {
             // This method does nothing
@@ -10,6 +16,15 @@ namespace ReflectorNet.Tests
         public bool NoParameters_ReturnBool()
         {
             return true;
+        }
+
+        public string SerializedMemberList_ReturnString
+        (
+            [Description(CustomDescriptionA)]
+            SerializedMemberList gameObjectDiffs
+        )
+        {
+            return "SerializedMemberList";
         }
     }
 }

--- a/ReflectorNet/src/Convertor/Json/MethodInfoConverter.cs
+++ b/ReflectorNet/src/Convertor/Json/MethodInfoConverter.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace com.IvanMurzak.ReflectorNet.Json
+{
+    public class MethodInfoConverter : JsonConverter<MethodInfo>
+    {
+        public override MethodInfo Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            using var doc = JsonDocument.ParseValue(ref reader);
+            var root = doc.RootElement;
+
+            var typeName = root.GetProperty("declaringType").GetString();
+            var methodName = root.GetProperty("name").GetString();
+            var parameterTypes = new List<Type>();
+
+            if (root.TryGetProperty("parameters", out var parametersElement))
+            {
+                foreach (var param in parametersElement.EnumerateArray())
+                {
+                    var paramTypeName = param.GetProperty("type").GetString();
+                    var paramType = Type.GetType(paramTypeName);
+                    if (paramType != null)
+                        parameterTypes.Add(paramType);
+                }
+            }
+
+            var declaringType = Type.GetType(typeName);
+            if (declaringType == null)
+                throw new JsonException($"Could not find type: {typeName}");
+
+            var method = declaringType.GetMethod(methodName, parameterTypes.ToArray());
+            if (method == null)
+                throw new JsonException($"Could not find method: {methodName} on type: {typeName}");
+
+            return method;
+        }
+
+        public override void Write(Utf8JsonWriter writer, MethodInfo value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            writer.WriteString("name", value.Name);
+            writer.WriteString("declaringType", value.DeclaringType?.AssemblyQualifiedName);
+
+            writer.WritePropertyName("parameters");
+            writer.WriteStartArray();
+            foreach (var param in value.GetParameters())
+            {
+                writer.WriteStartObject();
+                writer.WriteString("name", param.Name);
+                writer.WriteString("type", param.ParameterType.AssemblyQualifiedName);
+                writer.WriteEndObject();
+            }
+            writer.WriteEndArray();
+
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/ReflectorNet/src/Convertor/Json/SerializedMemberConverter.cs
+++ b/ReflectorNet/src/Convertor/Json/SerializedMemberConverter.cs
@@ -13,7 +13,7 @@ namespace com.IvanMurzak.ReflectorNet.Json
         public static string StaticId => typeof(SerializedMember).FullName;
         public static JsonNode Schema => new JsonObject
         {
-            ["id"] = StaticId,
+            [JsonUtils.SchemaId] = StaticId,
             ["type"] = "object",
             ["properties"] = new JsonObject
             {
@@ -29,7 +29,7 @@ namespace com.IvanMurzak.ReflectorNet.Json
                     ["type"] = "array",
                     ["items"] = new JsonObject
                     {
-                        ["$ref"] = StaticId
+                        [JsonUtils.SchemaRef] = StaticId
                     }
                 },
                 [nameof(SerializedMember.props)] = new JsonObject
@@ -37,7 +37,7 @@ namespace com.IvanMurzak.ReflectorNet.Json
                     ["type"] = "array",
                     ["items"] = new JsonObject
                     {
-                        ["$ref"] = StaticId
+                        [JsonUtils.SchemaRef] = StaticId
                     }
                 }
             },
@@ -45,7 +45,7 @@ namespace com.IvanMurzak.ReflectorNet.Json
         };
         public static JsonNode SchemaRef => new JsonObject
         {
-            ["$ref"] = StaticId
+            [JsonUtils.SchemaRef] = StaticId
         };
 
         public string Id => StaticId;

--- a/ReflectorNet/src/Convertor/Json/SerializedMemberListConverter.cs
+++ b/ReflectorNet/src/Convertor/Json/SerializedMemberListConverter.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using com.IvanMurzak.ReflectorNet.Model;
+using com.IvanMurzak.ReflectorNet.Utils;
 
 namespace com.IvanMurzak.ReflectorNet.Json
 {
@@ -11,18 +12,18 @@ namespace com.IvanMurzak.ReflectorNet.Json
         public static string StaticId => typeof(SerializedMemberList).FullName;
         public static JsonNode Schema => new JsonObject
         {
-            ["id"] = StaticId,
+            [JsonUtils.SchemaId] = StaticId,
             ["type"] = "array",
             ["items"] = new JsonObject
             {
-                ["$ref"] = SerializedMemberConverter.StaticId
+                [JsonUtils.SchemaRef] = SerializedMemberConverter.StaticId
             }
         };
         public string Id => StaticId;
         public JsonNode GetScheme() => Schema;
         public JsonNode GetSchemeRef() => new JsonObject
         {
-            ["$ref"] = Id
+            [JsonUtils.SchemaRef] = Id
         };
 
         public override SerializedMemberList? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)

--- a/ReflectorNet/src/Convertor/Reflection/PrimitiveReflectionConvertor.cs
+++ b/ReflectorNet/src/Convertor/Reflection/PrimitiveReflectionConvertor.cs
@@ -13,11 +13,7 @@ namespace com.IvanMurzak.ReflectorNet.Convertor
     {
         public override int SerializationPriority(Type type, ILogger? logger = null)
         {
-            var isPrimitive = type.IsPrimitive ||
-                type.IsEnum ||
-                type == typeof(string) ||
-                type == typeof(decimal) ||
-                type == typeof(DateTime);
+            var isPrimitive = TypeUtils.IsPrimitive(type);
 
             return isPrimitive
                 ? MAX_DEPTH + 1

--- a/ReflectorNet/src/Utils/Json/JsonUtils.cs
+++ b/ReflectorNet/src/Utils/Json/JsonUtils.cs
@@ -21,6 +21,7 @@ namespace com.IvanMurzak.ReflectorNet.Utils
             Converters =
             {
                 new JsonStringEnumConverter(),
+                new MethodInfoConverter(),
                 new SerializedMemberConverter(),
                 new SerializedMemberListConverter(),
 

--- a/ReflectorNet/src/Utils/TypeUtils.cs
+++ b/ReflectorNet/src/Utils/TypeUtils.cs
@@ -72,5 +72,16 @@ namespace com.IvanMurzak.ReflectorNet.Utils
             }
             return current == baseType ? distance : -1;
         }
+        public static bool IsPrimitive(Type type)
+        {
+            return type.IsPrimitive ||
+                   type.IsEnum ||
+                   type == typeof(string) ||
+                   type == typeof(decimal) ||
+                   type == typeof(DateTime) ||
+                   type == typeof(DateTimeOffset) ||
+                   type == typeof(TimeSpan) ||
+                   type == typeof(Guid);
+        }
     }
 }


### PR DESCRIPTION
This pull request introduces several enhancements and new features to the `ReflectorNet` project, focusing on improving test coverage, JSON serialization capabilities, and schema handling. The key changes include the addition of a base test class for consistent test output, updates to JSON schema utilities, and the introduction of a custom `MethodInfoConverter` for JSON serialization. Below is a categorized summary of the most important changes:

### Testing Enhancements:
* Added a new `BaseTest` class to provide a shared `_output` field for consistent test output logging across all test classes. (`ReflectorNet.Tests/BaseTest.cs`, [ReflectorNet.Tests/BaseTest.csR1-R14](diffhunk://#diff-06724d17176d6540d09656ec7dd1f95b23e5054010614847c027a30c017d5cceR1-R14))
* Updated `JsonSchemaTest` and `ReflectorTests` to inherit from `BaseTest`, enabling the use of `_output` for logging serialized schemas and method information. (`ReflectorNet.Tests/JsonSchemaTest.cs`, [[1]](diffhunk://#diff-180c0649ab9e514ad4aa6dace2dcda2cd694b6b7de53eaa86711b9346db36925R1-R29); `ReflectorNet.Tests/ReflectorTests.cs`, [[2]](diffhunk://#diff-45de51e6424908a30b91672cf9a329ed509d296d9427e8c787828591e622d9adL1-R12) [[3]](diffhunk://#diff-45de51e6424908a30b91672cf9a329ed509d296d9427e8c787828591e622d9adR33-R34) [[4]](diffhunk://#diff-45de51e6424908a30b91672cf9a329ed509d296d9427e8c787828591e622d9adR61-R62)

### JSON Serialization Improvements:
* Introduced a new `MethodInfoConverter` class for custom JSON serialization and deserialization of `MethodInfo` objects. (`ReflectorNet/src/Convertor/Json/MethodInfoConverter.cs`, [ReflectorNet/src/Convertor/Json/MethodInfoConverter.csR1-R62](diffhunk://#diff-99f43c6cee29a7d450e44273603ada23806589fa03692e53d2f1a08b45070a18R1-R62))
* Added the `MethodInfoConverter` to the default list of JSON converters in `JsonUtils`. (`ReflectorNet/src/Utils/Json/JsonUtils.cs`, [ReflectorNet/src/Utils/Json/JsonUtils.csR24](diffhunk://#diff-b24c5c5d6f646e5836a951c2957b05bdf4098732c9dbfb2bf37a23507dd1952aR24))

### JSON Schema Enhancements:
* Refactored schema definitions in `SerializedMemberConverter` and `SerializedMemberListConverter` to use constants from `JsonUtils` for `$id` and `$ref` keys, improving consistency and maintainability. (`ReflectorNet/src/Convertor/Json/SerializedMemberConverter.cs`, [[1]](diffhunk://#diff-9fc541231106e2e17e553f7b0981e31463349710c7782d4285a9c8124b5f7a76L16-R16) [[2]](diffhunk://#diff-9fc541231106e2e17e553f7b0981e31463349710c7782d4285a9c8124b5f7a76L32-R48); `ReflectorNet/src/Convertor/Json/SerializedMemberListConverter.cs`, [[3]](diffhunk://#diff-16b5b70c1de2eb0515c94da7581dab09cc9336c2fbc4e2b52de935482a2a3150L14-R26)
* Enhanced `JsonUtils.GetSchema` to include `$defs` for nested schema definitions and avoid duplication by tracking processed types. (`ReflectorNet/src/Utils/Json/JsonUtils.Schema.cs`, [[1]](diffhunk://#diff-6141a51428377febec6e8e8d9a7c8329066ea82eeee9cd5b4d4ab9a49e8af076R88-R131) [[2]](diffhunk://#diff-6141a51428377febec6e8e8d9a7c8329066ea82eeee9cd5b4d4ab9a49e8af076R146-R148)

### Utility Enhancements:
* Added a new `IsPrimitive` method to `TypeUtils` to centralize the logic for determining if a type is primitive, improving code reuse. (`ReflectorNet/src/Utils/TypeUtils.cs`, [ReflectorNet/src/Utils/TypeUtils.csR75-R85](diffhunk://#diff-4661f6891bb6a70ca7c4d44c49840c4a1ac0d84ee588ef7ea80825fb7ac2c373R75-R85))
* Updated `PrimitiveReflectionConvertor` to use the new `TypeUtils.IsPrimitive` method for determining serialization priority. (`ReflectorNet/src/Convertor/Reflection/PrimitiveReflectionConvertor.cs`, [ReflectorNet/src/Convertor/Reflection/PrimitiveReflectionConvertor.csL16-R16](diffhunk://#diff-9b81ce4cc2c0e5fde22ad2f33e7525d5eb0f260bfd9259fdd31660147f2264b2L16-R16))

### Test Class Updates:
* Added a new method `SerializedMemberList_ReturnString` to `TestClass` with a custom attribute for testing schema generation. (`ReflectorNet.Tests/TestClass.cs`, [ReflectorNet.Tests/TestClass.csR20-R28](diffhunk://#diff-33a5a06f5ef42a8c1374815b9cabc5dcba68deb64a2f4bebe6a63bf7f79449a3R20-R28))