### PR TITLE
fix: JSON schema custom property name support

### DIFF
--- a/ReflectorNet.Tests/Model/ObjectRefCustomPropertyName.cs
+++ b/ReflectorNet.Tests/Model/ObjectRefCustomPropertyName.cs
@@ -1,0 +1,24 @@
+using System.Text.Json.Serialization;
+
+namespace com.IvanMurzak.ReflectorNet.Tests.Model
+{
+    public class ModelWithDifferentFieldsAndProperties
+    {
+        public const string IntField = "int_Field";
+        public const string IntFieldNullable = "int_Field_Nullable";
+        public const string IntProperty = "int_Property";
+        public const string IntPropertyNullable = "int_Property_Nullable";
+
+        [JsonInclude, JsonPropertyName(IntField)]
+        public int intField;
+
+        [JsonInclude, JsonPropertyName(IntFieldNullable)]
+        public int? intFieldNullable;
+
+        [JsonInclude, JsonPropertyName(IntProperty)]
+        public int intProperty { get; set; }
+
+        [JsonInclude, JsonPropertyName(IntPropertyNullable)]
+        public int? intPropertyNullable { get; set; }
+    }
+}

--- a/ReflectorNet.Tests/SchemaTests/SchemaTestBase.cs
+++ b/ReflectorNet.Tests/SchemaTests/SchemaTestBase.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Reflection;
+using System.Text.Json.Nodes;
 using com.IvanMurzak.ReflectorNet.Utils;
 using Xunit.Abstractions;
 
@@ -12,7 +13,7 @@ namespace com.IvanMurzak.ReflectorNet.Tests.SchemaTests
         {
         }
 
-        protected void JsonSchemaValidation(Type type, Reflector? reflector = null)
+        protected JsonNode? JsonSchemaValidation(Type type, Reflector? reflector = null)
         {
             reflector ??= new Reflector();
 
@@ -27,6 +28,7 @@ namespace com.IvanMurzak.ReflectorNet.Tests.SchemaTests
                 Assert.Fail(errorValue!.ToString());
             }
             Assert.NotNull(schema.AsObject());
+            return schema;
         }
 
         protected void TestMethodInputs_PropertyRefs(Reflector? reflector, MethodInfo methodInfo, params string[] parameterNames)
@@ -67,7 +69,7 @@ namespace com.IvanMurzak.ReflectorNet.Tests.SchemaTests
             }
         }
 
-        protected void TestMethodInputs_Defines(Reflector? reflector, MethodInfo methodInfo, params Type[] expectedTypes)
+        protected JsonNode? TestMethodInputs_Defines(Reflector? reflector, MethodInfo methodInfo, params Type[] expectedTypes)
         {
             reflector ??= new Reflector();
 
@@ -90,6 +92,8 @@ namespace com.IvanMurzak.ReflectorNet.Tests.SchemaTests
                 var targetDefine = defines[typeId];
                 Assert.NotNull(targetDefine);
             }
+
+            return schema;
         }
     }
 }

--- a/ReflectorNet.Tests/SchemaTests/SchemaTests.cs
+++ b/ReflectorNet.Tests/SchemaTests/SchemaTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Reflection;
+using System.Text.Json.Nodes;
 using com.IvanMurzak.ReflectorNet.Json;
 using com.IvanMurzak.ReflectorNet.Model;
 using com.IvanMurzak.ReflectorNet.Tests.Model;
@@ -116,73 +117,37 @@ namespace com.IvanMurzak.ReflectorNet.Tests.SchemaTests
             var reflector = new Reflector();
             var schema = JsonSchemaValidation(typeof(ModelWithDifferentFieldsAndProperties), reflector);
 
-            // Null check for schema
+            // Validate schema structure
             Assert.NotNull(schema);
-
-            // Validate schema has Properties section
             Assert.True(schema.AsObject().ContainsKey(JsonSchema.Properties),
                 $"Schema should contain '{JsonSchema.Properties}' property. Available properties: {string.Join(", ", schema.AsObject().Select(x => x.Key))}");
 
             var properties = schema[JsonSchema.Properties];
             Assert.NotNull(properties);
 
-            // ----------------------------------
+            // Test each expected property with custom JSON property names
+            ValidateIntegerProperty(properties, ModelWithDifferentFieldsAndProperties.IntField);
+            ValidateIntegerProperty(properties, ModelWithDifferentFieldsAndProperties.IntFieldNullable);
+            ValidateIntegerProperty(properties, ModelWithDifferentFieldsAndProperties.IntProperty);
+            ValidateIntegerProperty(properties, ModelWithDifferentFieldsAndProperties.IntPropertyNullable);
+        }
 
-            // Validate fields section contains expected IntField
-            Assert.True(properties.AsObject().ContainsKey(ModelWithDifferentFieldsAndProperties.IntField),
-                $"Fields should contain '{ModelWithDifferentFieldsAndProperties.IntField}' field. Available fields: {string.Join(", ", properties.AsObject().Select(x => x.Key))}");
+        private static void ValidateIntegerProperty(JsonNode properties, string propertyName)
+        {
+            // Validate property exists
+            Assert.True(properties.AsObject().ContainsKey(propertyName),
+                $"Properties should contain '{propertyName}' property. Available properties: {string.Join(", ", properties.AsObject().Select(x => x.Key))}");
 
-            var intFieldSchema = properties[ModelWithDifferentFieldsAndProperties.IntField];
-            Assert.NotNull(intFieldSchema);
+            var propertySchema = properties[propertyName];
+            Assert.NotNull(propertySchema);
 
-            Assert.True(intFieldSchema.AsObject().ContainsKey(JsonSchema.Type),
-                $"{ModelWithDifferentFieldsAndProperties.IntField} schema should contain '{JsonSchema.Type}' property. Available properties: {string.Join(", ", intFieldSchema.AsObject().Select(x => x.Key))}");
+            // Validate property has type field
+            Assert.True(propertySchema.AsObject().ContainsKey(JsonSchema.Type),
+                $"Property '{propertyName}' schema should contain '{JsonSchema.Type}' field. Available fields: {string.Join(", ", propertySchema.AsObject().Select(x => x.Key))}");
 
-            var intFieldType = intFieldSchema[JsonSchema.Type];
-            Assert.NotNull(intFieldType);
-            Assert.Equal(JsonSchema.Integer, intFieldType.ToString());
-
-            // Validate fields section contains expected IntFieldNullable
-            Assert.True(properties.AsObject().ContainsKey(ModelWithDifferentFieldsAndProperties.IntFieldNullable),
-                $"Fields should contain '{ModelWithDifferentFieldsAndProperties.IntFieldNullable}' field. Available fields: {string.Join(", ", properties.AsObject().Select(x => x.Key))}");
-
-            var intFieldNullableSchema = properties[ModelWithDifferentFieldsAndProperties.IntFieldNullable];
-            Assert.NotNull(intFieldNullableSchema);
-
-            Assert.True(intFieldNullableSchema.AsObject().ContainsKey(JsonSchema.Type),
-                $"{ModelWithDifferentFieldsAndProperties.IntFieldNullable} schema should contain '{JsonSchema.Type}' property. Available properties: {string.Join(", ", intFieldNullableSchema.AsObject().Select(x => x.Key))}");
-
-            var intFieldNullableType = intFieldNullableSchema[JsonSchema.Type];
-            Assert.NotNull(intFieldNullableType);
-            Assert.Equal(JsonSchema.Integer, intFieldNullableType.ToString());
-
-            // Validate props section contains expected IntProperty
-            Assert.True(properties.AsObject().ContainsKey(ModelWithDifferentFieldsAndProperties.IntProperty),
-                $"Props should contain '{ModelWithDifferentFieldsAndProperties.IntProperty}' property. Available props: {string.Join(", ", properties.AsObject().Select(x => x.Key))}");
-
-            var intPropertySchema = properties[ModelWithDifferentFieldsAndProperties.IntProperty];
-            Assert.NotNull(intPropertySchema);
-
-            Assert.True(intPropertySchema.AsObject().ContainsKey(JsonSchema.Type),
-                $"{ModelWithDifferentFieldsAndProperties.IntProperty} schema should contain '{JsonSchema.Type}' property. Available properties: {string.Join(", ", intPropertySchema.AsObject().Select(x => x.Key))}");
-
-            var intPropertyType = intPropertySchema[JsonSchema.Type];
-            Assert.NotNull(intPropertyType);
-            Assert.Equal(JsonSchema.Integer, intPropertyType.ToString());
-
-            // Validate props section contains expected IntPropertyNullable
-            Assert.True(properties.AsObject().ContainsKey(ModelWithDifferentFieldsAndProperties.IntPropertyNullable),
-                $"Props should contain '{ModelWithDifferentFieldsAndProperties.IntPropertyNullable}' property. Available props: {string.Join(", ", properties.AsObject().Select(x => x.Key))}");
-
-            var intPropertyNullableSchema = properties[ModelWithDifferentFieldsAndProperties.IntPropertyNullable];
-            Assert.NotNull(intPropertyNullableSchema);
-
-            Assert.True(intPropertyNullableSchema.AsObject().ContainsKey(JsonSchema.Type),
-                $"{ModelWithDifferentFieldsAndProperties.IntPropertyNullable} schema should contain '{JsonSchema.Type}' property. Available properties: {string.Join(", ", intPropertyNullableSchema.AsObject().Select(x => x.Key))}");
-
-            var intPropertyNullableType = intPropertyNullableSchema[JsonSchema.Type];
-            Assert.NotNull(intPropertyNullableType);
-            Assert.Equal(JsonSchema.Integer, intPropertyNullableType.ToString());
+            var propertyType = propertySchema[JsonSchema.Type];
+            Assert.NotNull(propertyType);
+            Assert.Equal(JsonSchema.Integer, propertyType.ToString());
         }
     }
 }

--- a/ReflectorNet.Tests/SchemaTests/SchemaTests.cs
+++ b/ReflectorNet.Tests/SchemaTests/SchemaTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Reflection;
 using com.IvanMurzak.ReflectorNet.Json;
 using com.IvanMurzak.ReflectorNet.Model;
@@ -107,6 +108,81 @@ namespace com.IvanMurzak.ReflectorNet.Tests.SchemaTests
 
             reflector.JsonSerializer.AddConverter(new MethodInfoConverter());
             JsonSchemaValidation(typeof(MethodInfo), reflector);
+        }
+
+        [Fact]
+        void JsonPropertyName_Attribute()
+        {
+            var reflector = new Reflector();
+            var schema = JsonSchemaValidation(typeof(ModelWithDifferentFieldsAndProperties), reflector);
+
+            // Null check for schema
+            Assert.NotNull(schema);
+
+            // Validate schema has Properties section
+            Assert.True(schema.AsObject().ContainsKey(JsonSchema.Properties),
+                $"Schema should contain '{JsonSchema.Properties}' property. Available properties: {string.Join(", ", schema.AsObject().Select(x => x.Key))}");
+
+            var properties = schema[JsonSchema.Properties];
+            Assert.NotNull(properties);
+
+            // ----------------------------------
+
+            // Validate fields section contains expected IntField
+            Assert.True(properties.AsObject().ContainsKey(ModelWithDifferentFieldsAndProperties.IntField),
+                $"Fields should contain '{ModelWithDifferentFieldsAndProperties.IntField}' field. Available fields: {string.Join(", ", properties.AsObject().Select(x => x.Key))}");
+
+            var intFieldSchema = properties[ModelWithDifferentFieldsAndProperties.IntField];
+            Assert.NotNull(intFieldSchema);
+
+            Assert.True(intFieldSchema.AsObject().ContainsKey(JsonSchema.Type),
+                $"{ModelWithDifferentFieldsAndProperties.IntField} schema should contain '{JsonSchema.Type}' property. Available properties: {string.Join(", ", intFieldSchema.AsObject().Select(x => x.Key))}");
+
+            var intFieldType = intFieldSchema[JsonSchema.Type];
+            Assert.NotNull(intFieldType);
+            Assert.Equal(JsonSchema.Integer, intFieldType.ToString());
+
+            // Validate fields section contains expected IntFieldNullable
+            Assert.True(properties.AsObject().ContainsKey(ModelWithDifferentFieldsAndProperties.IntFieldNullable),
+                $"Fields should contain '{ModelWithDifferentFieldsAndProperties.IntFieldNullable}' field. Available fields: {string.Join(", ", properties.AsObject().Select(x => x.Key))}");
+
+            var intFieldNullableSchema = properties[ModelWithDifferentFieldsAndProperties.IntFieldNullable];
+            Assert.NotNull(intFieldNullableSchema);
+
+            Assert.True(intFieldNullableSchema.AsObject().ContainsKey(JsonSchema.Type),
+                $"{ModelWithDifferentFieldsAndProperties.IntFieldNullable} schema should contain '{JsonSchema.Type}' property. Available properties: {string.Join(", ", intFieldNullableSchema.AsObject().Select(x => x.Key))}");
+
+            var intFieldNullableType = intFieldNullableSchema[JsonSchema.Type];
+            Assert.NotNull(intFieldNullableType);
+            Assert.Equal(JsonSchema.Integer, intFieldNullableType.ToString());
+
+            // Validate props section contains expected IntProperty
+            Assert.True(properties.AsObject().ContainsKey(ModelWithDifferentFieldsAndProperties.IntProperty),
+                $"Props should contain '{ModelWithDifferentFieldsAndProperties.IntProperty}' property. Available props: {string.Join(", ", properties.AsObject().Select(x => x.Key))}");
+
+            var intPropertySchema = properties[ModelWithDifferentFieldsAndProperties.IntProperty];
+            Assert.NotNull(intPropertySchema);
+
+            Assert.True(intPropertySchema.AsObject().ContainsKey(JsonSchema.Type),
+                $"{ModelWithDifferentFieldsAndProperties.IntProperty} schema should contain '{JsonSchema.Type}' property. Available properties: {string.Join(", ", intPropertySchema.AsObject().Select(x => x.Key))}");
+
+            var intPropertyType = intPropertySchema[JsonSchema.Type];
+            Assert.NotNull(intPropertyType);
+            Assert.Equal(JsonSchema.Integer, intPropertyType.ToString());
+
+            // Validate props section contains expected IntPropertyNullable
+            Assert.True(properties.AsObject().ContainsKey(ModelWithDifferentFieldsAndProperties.IntPropertyNullable),
+                $"Props should contain '{ModelWithDifferentFieldsAndProperties.IntPropertyNullable}' property. Available props: {string.Join(", ", properties.AsObject().Select(x => x.Key))}");
+
+            var intPropertyNullableSchema = properties[ModelWithDifferentFieldsAndProperties.IntPropertyNullable];
+            Assert.NotNull(intPropertyNullableSchema);
+
+            Assert.True(intPropertyNullableSchema.AsObject().ContainsKey(JsonSchema.Type),
+                $"{ModelWithDifferentFieldsAndProperties.IntPropertyNullable} schema should contain '{JsonSchema.Type}' property. Available properties: {string.Join(", ", intPropertyNullableSchema.AsObject().Select(x => x.Key))}");
+
+            var intPropertyNullableType = intPropertyNullableSchema[JsonSchema.Type];
+            Assert.NotNull(intPropertyNullableType);
+            Assert.Equal(JsonSchema.Integer, intPropertyNullableType.ToString());
         }
     }
 }

--- a/ReflectorNet/ReflectorNet.csproj
+++ b/ReflectorNet/ReflectorNet.csproj
@@ -9,7 +9,7 @@
 
     <!-- NuGet Package Information -->
     <PackageId>com.IvanMurzak.ReflectorNet</PackageId>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <Authors>Ivan Murzak</Authors>
     <Copyright>Copyright © Ivan Murzak 2025</Copyright>
     <Description>ReflectorNet is an advanced .NET reflection toolkit designed for AI-driven scenarios. Effortlessly search for C# methods using natural language queries, invoke any method by supplying arguments as JSON, and receive results as JSON. The library also provides a powerful API to inspect, modify, and manage in-memory object instances dynamically via JSON data. Ideal for automation, testing, and AI integration workflows.</Description>

--- a/ReflectorNet/src/Utils/Json/JsonSchema.Internal.cs
+++ b/ReflectorNet/src/Utils/Json/JsonSchema.Internal.cs
@@ -8,7 +8,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 
 namespace com.IvanMurzak.ReflectorNet.Utils
 {
@@ -133,6 +135,7 @@ namespace com.IvanMurzak.ReflectorNet.Utils
             {
                 foreach (var field in fields)
                 {
+                    var fieldName = field.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name ?? field.Name;
                     var fieldSchema = GetSchema(reflector, field.FieldType, justRef: !TypeUtils.IsPrimitive(field.FieldType));
 
                     // Add description if available
@@ -140,12 +143,12 @@ namespace com.IvanMurzak.ReflectorNet.Utils
                     if (!string.IsNullOrEmpty(description) && fieldSchema is JsonObject fieldSchemaObj)
                         fieldSchemaObj[Description] = JsonValue.Create(description);
 
-                    properties![field.Name] = fieldSchema;
+                    properties![fieldName] = fieldSchema;
 
                     // Fields are typically required unless they are nullable
                     var underlyingType = Nullable.GetUnderlyingType(field.FieldType);
                     if (underlyingType == null && !field.FieldType.IsClass)
-                        required.Add(field.Name);
+                        required.Add(fieldName);
                 }
             }
 
@@ -155,6 +158,7 @@ namespace com.IvanMurzak.ReflectorNet.Utils
             {
                 foreach (var prop in props)
                 {
+                    var propName = prop.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name ?? prop.Name;
                     var propSchema = GetSchema(reflector, prop.PropertyType, justRef: !TypeUtils.IsPrimitive(prop.PropertyType));
 
                     // Add description if available
@@ -162,12 +166,12 @@ namespace com.IvanMurzak.ReflectorNet.Utils
                     if (!string.IsNullOrEmpty(description) && propSchema is JsonObject propSchemaObj)
                         propSchemaObj[Description] = JsonValue.Create(description);
 
-                    properties![prop.Name] = propSchema;
+                    properties![propName] = propSchema;
 
                     // Properties are required if they are value types and not nullable
                     var underlyingType = Nullable.GetUnderlyingType(prop.PropertyType);
                     if (underlyingType == null && !prop.PropertyType.IsClass && prop.CanWrite)
-                        required.Add(prop.Name);
+                        required.Add(propName);
                 }
             }
 


### PR DESCRIPTION
This pull request adds support for honoring the `JsonPropertyName` attribute when generating JSON schemas, ensuring that field and property names in the schema match their custom serialization names. It also adds comprehensive tests to verify this behavior and makes minor improvements to test utilities.

**Support for `JsonPropertyName` attribute in schema generation:**

* Updated `GenerateSchemaFromType` in `JsonSchema.Internal.cs` to use the `JsonPropertyName` attribute for both fields and properties when generating schema property names and required lists. This ensures the schema reflects any custom serialization names. [[1]](diffhunk://#diff-0fa33a3329a228841b4c3d096521edffc09a1d0e74e09c5f2494ec839e1941beR138-R151) [[2]](diffhunk://#diff-0fa33a3329a228841b4c3d096521edffc09a1d0e74e09c5f2494ec839e1941beR161-R174)

**Testing and validation:**

* Added a new model `ModelWithDifferentFieldsAndProperties` with fields and properties decorated with `JsonPropertyName` for testing.
* Added a new test case `JsonPropertyName_Attribute` in `SchemaTests.cs` to verify that the generated schema correctly uses custom property names and types as specified by the `JsonPropertyName` attribute.

**Test utilities and infrastructure:**

* Modified `JsonSchemaValidation` and `TestMethodInputs_Defines` in `SchemaTestBase.cs` to return the generated `JsonNode` schema, allowing for more flexible and thorough assertions in tests. [[1]](diffhunk://#diff-c8746babaaafc5d2976ffa006568ecd1ba972ffaece19ad14433339d9858fcafL15-R16) [[2]](diffhunk://#diff-c8746babaaafc5d2976ffa006568ecd1ba972ffaece19ad14433339d9858fcafR31) [[3]](diffhunk://#diff-c8746babaaafc5d2976ffa006568ecd1ba972ffaece19ad14433339d9858fcafL70-R72) [[4]](diffhunk://#diff-c8746babaaafc5d2976ffa006568ecd1ba972ffaece19ad14433339d9858fcafR95-R96)
* Added necessary `using` statements for `System.Text.Json.Nodes` and `System.Text.Json.Serialization` in relevant files to support new functionality. [[1]](diffhunk://#diff-c8746babaaafc5d2976ffa006568ecd1ba972ffaece19ad14433339d9858fcafR4) [[2]](diffhunk://#diff-0fa33a3329a228841b4c3d096521edffc09a1d0e74e09c5f2494ec839e1941beR11-R13) [[3]](diffhunk://#diff-f5f4972d81160e913467c3b1c00079e52556baacdbe3f2f0e1e4a1e8f8c593fcR2)

**Versioning:**

* Bumped the library version to `1.0.2` in `ReflectorNet.csproj` to reflect the new feature.