### PR TITLE
feat: enhance schema generation to support value types for additional…

### DIFF
--- a/ReflectorNet/src/Utils/Json/JsonSchema.Internal.cs
+++ b/ReflectorNet/src/Utils/Json/JsonSchema.Internal.cs
@@ -125,6 +125,7 @@ namespace com.IvanMurzak.ReflectorNet.Utils
                     if (defines.ContainsKey(typeId) == false)
                     {
                         // Add placeholder first to prevent infinite recursion
+                        defines[typeId] = new JsonObject { [Type] = Array };
                         defines[typeId] = new JsonObject
                         {
                             [Type] = Array,


### PR DESCRIPTION
This pull request updates the logic for generating JSON schema definitions for generic types in the `GetSchema` method. The main improvement is that the schema now uses the value type's schema for `additionalProperties` when the generic type has at least two type arguments, making the schema more accurate and descriptive.

Enhancement to JSON schema generation:

* In `JsonSchema.cs`, the `GetSchema` method now checks if the generic type has two or more arguments and, if so, sets `additionalProperties` in the schema to the value type's schema instead of just `true`. This provides a more precise schema for dictionaries and similar types.…Properties