### PR TITLE
Simplify test for Task nullable custom type schema

### DIFF
--- a/ReflectorNet.Tests/SchemaTests/ReturnSchemaTests.cs
+++ b/ReflectorNet.Tests/SchemaTests/ReturnSchemaTests.cs
@@ -254,7 +254,7 @@ namespace com.IvanMurzak.ReflectorNet.Tests.SchemaTests
             AssertAllRefsDefined(schema!);
         }
 
-        [Theory]
+        [Fact]
         public void GetReturnSchema_TaskNullableCustomType_UnwrapsToCustomTypeSchemaWithoutRequired()
         {
             var schema = GetReturnSchemaForMethod(nameof(TaskNullableCustomTypeMethod));


### PR DESCRIPTION
Removed conditional InlineData and hardcoded shouldBeRequired to false in GetReturnSchema_TaskNullableCustomType_UnwrapsToCustomTypeSchemaWithoutRequired test for consistency across frameworks.