### PR TITLE
Add TypeJsonConverter and refactor deserialization methods for improved type handling

### DIFF
--- a/ReflectorNet/src/Convertor/Json/TypeJsonConverter.cs
+++ b/ReflectorNet/src/Convertor/Json/TypeJsonConverter.cs
@@ -1,0 +1,66 @@
+/*
+ * ReflectorNet
+ * Author: Ivan Murzak (https://github.com/IvanMurzak)
+ * Copyright (c) 2025 Ivan Murzak
+ * Licensed under the Apache License, Version 2.0. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using com.IvanMurzak.ReflectorNet.Utils;
+
+namespace com.IvanMurzak.ReflectorNet.Json
+{
+    /// <summary>
+    /// JsonConverter that handles conversion between JSON string values and System.Type.
+    /// Supports nullable Type and uses fully qualified type names for serialization.
+    /// </summary>
+    public class TypeJsonConverter : JsonSchemaConverter<Type>, IJsonSchemaConverter
+    {
+        public static JsonNode Schema => new JsonObject
+        {
+            [JsonSchema.Type] = JsonSchema.String
+        };
+        public static JsonNode SchemaRef => new JsonObject
+        {
+            [JsonSchema.Ref] = JsonSchema.RefValue + StaticId
+        };
+
+        public override JsonNode GetSchemaRef() => SchemaRef;
+        public override JsonNode GetSchema() => Schema;
+
+        public override bool CanConvert(Type typeToConvert)
+        {
+            var underlyingType = Nullable.GetUnderlyingType(typeToConvert) ?? typeToConvert;
+            return underlyingType == typeof(Type);
+        }
+
+        public override Type? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            // Handle null values for nullable types
+            if (reader.TokenType == JsonTokenType.Null)
+                return null;
+
+            // Handle string tokens
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                var stringValue = reader.GetString();
+                return TypeUtils.GetType(stringValue);
+            }
+
+            throw new JsonException($"Expected string which represents System.Type in the format `System.Int32`");
+        }
+
+        public override void Write(Utf8JsonWriter writer, Type value, JsonSerializerOptions options)
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            writer.WriteStringValue(value.GetTypeName(pretty: false));
+        }
+    }
+}

--- a/ReflectorNet/src/Convertor/Reflection/Base/BaseReflectionConvertor.Deserialize.cs
+++ b/ReflectorNet/src/Convertor/Reflection/Base/BaseReflectionConvertor.Deserialize.cs
@@ -60,8 +60,9 @@ namespace com.IvanMurzak.ReflectorNet.Convertor
             ILogger? logger = null,
             DeserializationContext? context = null)
         {
-            if (!TryDeserializeValue(reflector,
-                serializedMember: data,
+            if (!TryDeserializeValue(
+                reflector,
+                data: data,
                 result: out var result,
                 type: out var type,
                 fallbackType: fallbackType,
@@ -200,7 +201,7 @@ namespace com.IvanMurzak.ReflectorNet.Convertor
         /// - Maintains type safety throughout the deserialization process
         /// </summary>
         /// <param name="reflector">The Reflector instance used for type resolution and recursive operations.</param>
-        /// <param name="serializedMember">The SerializedMember containing the data to deserialize.</param>
+        /// <param name="data">The SerializedMember containing the data to deserialize.</param>
         /// <param name="result">Output parameter containing the deserialized object on success.</param>
         /// <param name="type">Output parameter containing the resolved target type.</param>
         /// <param name="fallbackType">Optional fallback type when type resolution from data fails.</param>
@@ -210,7 +211,7 @@ namespace com.IvanMurzak.ReflectorNet.Convertor
         /// <returns>True if deserialization succeeded, false otherwise.</returns>
         protected virtual bool TryDeserializeValue(
             Reflector reflector,
-            SerializedMember? serializedMember,
+            SerializedMember? data,
             out object? result,
             out Type? type,
             Type? fallbackType = null,
@@ -218,7 +219,7 @@ namespace com.IvanMurzak.ReflectorNet.Convertor
             StringBuilder? stringBuilder = null,
             ILogger? logger = null)
         {
-            if (serializedMember == null)
+            if (data == null)
             {
                 result = null;
                 type = null;
@@ -228,7 +229,7 @@ namespace com.IvanMurzak.ReflectorNet.Convertor
             var padding = StringUtils.GetPadding(depth);
 
             // Get the most appropriate type for deserialization
-            type = TypeUtils.GetTypeWithNamePriority(serializedMember, fallbackType, out var error);
+            type = TypeUtils.GetTypeWithNamePriority(data, fallbackType, out var error);
             if (type == null)
             {
                 result = null;
@@ -238,11 +239,11 @@ namespace com.IvanMurzak.ReflectorNet.Convertor
             }
 
             if (logger?.IsEnabled(LogLevel.Trace) == true)
-                logger.LogTrace($"{padding}{Consts.Emoji.Start} Deserialize 'value', type='{type.GetTypeShortName()}' name='{serializedMember.name.ValueOrNull()}'.");
+                logger.LogTrace($"{padding}{Consts.Emoji.Start} Deserialize 'value', type='{type.GetTypeShortName()}' name='{data.name.ValueOrNull()}'.");
 
             var success = TryDeserializeValueInternal(
                 reflector,
-                data: serializedMember,
+                data: data,
                 result: out result,
                 type: type,
                 depth: depth,

--- a/ReflectorNet/src/Convertor/Reflection/GenericReflectionConvertor.cs
+++ b/ReflectorNet/src/Convertor/Reflection/GenericReflectionConvertor.cs
@@ -94,7 +94,7 @@ namespace com.IvanMurzak.ReflectorNet.Convertor
 
             if (!TryDeserializeValue(
                 reflector,
-                serializedMember: value,
+                data: value,
                 result: out var parsedValue,
                 type: out var type,
                 fallbackType: fallbackType,
@@ -105,6 +105,14 @@ namespace com.IvanMurzak.ReflectorNet.Convertor
                 stringBuilder?.AppendLine($"{padding}[Error] Failed to deserialize value for field '{fieldInfo.Name}'.");
                 return false;
             }
+
+            // Check if field type matches parsed value type
+            if (!TypeUtils.IsCastable(type, fieldInfo.FieldType))
+            {
+                stringBuilder?.AppendLine($"{padding}[Error] Parsed value type '{type.GetTypeName(pretty: false)}' is not assignable to field type '{fieldInfo.FieldType.GetTypeName(pretty: false)}' for field '{fieldInfo.Name}'.");
+                return false;
+            }
+
             // TODO: Print previous and new value in stringBuilder
             fieldInfo.SetValue(obj, parsedValue);
             if (stringBuilder != null)
@@ -125,9 +133,16 @@ namespace com.IvanMurzak.ReflectorNet.Convertor
         {
             var padding = StringUtils.GetPadding(depth);
 
+            // Check if property is writable
+            if (!propertyInfo.CanWrite)
+            {
+                stringBuilder?.AppendLine($"{padding}[Error] Property '{propertyInfo.Name}' is read-only.");
+                return false;
+            }
+
             if (!TryDeserializeValue(
                 reflector,
-                serializedMember: value,
+                data: value,
                 result: out var parsedValue,
                 type: out var type,
                 fallbackType: fallbackType,
@@ -138,6 +153,14 @@ namespace com.IvanMurzak.ReflectorNet.Convertor
                 stringBuilder?.AppendLine($"{padding}[Error] Failed to deserialize value for property '{propertyInfo.Name}'.");
                 return false;
             }
+
+            // Check if property type matches parsed value type
+            if (!TypeUtils.IsCastable(type, propertyInfo.PropertyType))
+            {
+                stringBuilder?.AppendLine($"{padding}[Error] Parsed value type '{type.GetTypeName(pretty: false)}' is not assignable to property type '{propertyInfo.PropertyType.GetTypeName(pretty: false)}' for property '{propertyInfo.Name}'.");
+                return false;
+            }
+
             // TODO: Print previous and new value in stringBuilder
             propertyInfo.SetValue(obj, parsedValue);
             if (stringBuilder != null)

--- a/ReflectorNet/src/Utils/Json/JsonSerializer.cs
+++ b/ReflectorNet/src/Utils/Json/JsonSerializer.cs
@@ -105,6 +105,7 @@ namespace com.IvanMurzak.ReflectorNet.Utils
                     new DecimalJsonConverter(),
                     new GuidJsonConverter(),
                     new TimeSpanJsonConverter(),
+                    new TypeJsonConverter(),
 
                     // Json converters
                     new JsonElementJsonConverter(),

--- a/ReflectorNet/src/Utils/TypeUtils.cs
+++ b/ReflectorNet/src/Utils/TypeUtils.cs
@@ -184,7 +184,27 @@ namespace com.IvanMurzak.ReflectorNet.Utils
             return fieldInfo != null ? GetFieldDescription(fieldInfo) : null;
         }
 
-        public static bool IsCastable(Type type, Type to)
+        /// <summary>
+        /// Checks if an object's runtime type is assignable to the target type.
+        /// This is a cross-platform alternative to Type.IsAssignableTo which is only available in .NET 5+.
+        /// </summary>
+        /// <param name="obj">The object to check (can be null)</param>
+        /// <param name="targetType">The target type to check assignability to</param>
+        /// <returns>True if the object can be assigned to the target type</returns>
+        public static bool IsAssignableTo(object? obj, Type targetType)
+        {
+            if (targetType == null)
+                return false;
+
+            // Null is assignable to any reference type or nullable value type
+            if (obj == null)
+                return !targetType.IsValueType || Nullable.GetUnderlyingType(targetType) != null;
+
+            // Check if the object's type is assignable to the target type
+            return targetType.IsAssignableFrom(obj.GetType());
+        }
+
+        public static bool IsCastable(Type? type, Type to)
         {
             if (type == null || to == null)
                 return false;


### PR DESCRIPTION
- Introduced TypeJsonConverter to handle conversion between JSON string values and System.Type.
- Refactored deserialization methods across various reflection converters to improve readability and maintainability.
- Updated parameter names for clarity, replacing 'serializedMember' with 'data'.
- Added checks for property and field type assignability during deserialization.