### PR TITLE
feat: Add batch blacklist methods for types and string names in Reflector

### DIFF
--- a/ReflectorNet/ReflectorNet.csproj
+++ b/ReflectorNet/ReflectorNet.csproj
@@ -9,7 +9,7 @@
 
     <!-- NuGet Package Information -->
     <PackageId>com.IvanMurzak.ReflectorNet</PackageId>
-    <Version>3.5.0</Version>
+    <Version>3.6.0</Version>
     <Authors>Ivan Murzak</Authors>
     <Copyright>Copyright © Ivan Murzak 2025</Copyright>
     <Description>ReflectorNet is an advanced .NET reflection toolkit designed for AI-driven scenarios. Effortlessly search for C# methods using natural language queries, invoke any method by supplying arguments as JSON, and receive results as JSON. The library also provides a powerful API to inspect, modify, and manage in-memory object instances dynamically via JSON data. Ideal for automation, testing, and AI integration workflows.</Description>

--- a/ReflectorNet/src/Reflector/Reflector.Registry.cs
+++ b/ReflectorNet/src/Reflector/Reflector.Registry.cs
@@ -108,14 +108,19 @@ namespace com.IvanMurzak.ReflectorNet
             /// <summary>
             /// Adds a type to the blacklist, preventing it from being processed by any converter.
             /// </summary>
-            /// <param name="type"></param>
-            public void BlacklistType(Type type)
+            /// <param name="type">The type to add to the blacklist.</param>
+            /// <returns>True if the type was added; false if it was null or already blacklisted.</returns>
+            public bool BlacklistType(Type type)
             {
                 if (type == null)
-                    return;
+                    return false;
 
                 if (_blacklistedTypes.TryAdd(type, 0))
+                {
                     _blacklistCache = new ConcurrentDictionary<Type, bool>(); // Invalidate cache when blacklist changes
+                    return true;
+                }
+                return false;
             }
 
             /// <summary>
@@ -123,7 +128,8 @@ namespace com.IvanMurzak.ReflectorNet
             /// The blacklist cache is only invalidated if at least one new type was added.
             /// </summary>
             /// <param name="types">The types to add to the blacklist. Null values are ignored.</param>
-            public void BlacklistTypes(params Type[] types)
+            /// <returns>True if at least one type was added; false if all types were null or already blacklisted.</returns>
+            public bool BlacklistTypes(params Type[] types)
             {
                 var changed = false;
                 foreach (var type in types)
@@ -133,6 +139,7 @@ namespace com.IvanMurzak.ReflectorNet
                 }
                 if (changed)
                     _blacklistCache = new ConcurrentDictionary<Type, bool>(); // Invalidate cache when blacklist changes
+                return changed;
             }
 
             /// <summary>
@@ -140,11 +147,13 @@ namespace com.IvanMurzak.ReflectorNet
             /// The type is resolved using <see cref="TypeUtils.GetType(string)"/>.
             /// </summary>
             /// <param name="typeFullName">The full name of the type to blacklist (e.g., "System.String").</param>
-            public void BlacklistType(string typeFullName)
+            /// <returns>True if the type was resolved and added; false if the type could not be resolved or was already blacklisted.</returns>
+            public bool BlacklistType(string typeFullName)
             {
                 var type = TypeUtils.GetType(typeFullName);
                 if (type != null)
-                    BlacklistType(type);
+                    return BlacklistType(type);
+                return false;
             }
 
             /// <summary>
@@ -153,7 +162,8 @@ namespace com.IvanMurzak.ReflectorNet
             /// if at least one new type was successfully resolved and added.
             /// </summary>
             /// <param name="typeFullNames">The full names of the types to blacklist (e.g., "System.String", "System.Int32").</param>
-            public void BlacklistTypes(params string[] typeFullNames)
+            /// <returns>True if at least one type was resolved and added; false if all types could not be resolved or were already blacklisted.</returns>
+            public bool BlacklistTypes(params string[] typeFullNames)
             {
                 var changed = false;
                 foreach (var typeFullName in typeFullNames)
@@ -164,6 +174,7 @@ namespace com.IvanMurzak.ReflectorNet
                 }
                 if (changed)
                     _blacklistCache = new ConcurrentDictionary<Type, bool>(); // Invalidate cache when blacklist changes
+                return changed;
             }
 
             /// <summary>


### PR DESCRIPTION
This pull request adds comprehensive support for batch blacklisting of types, both by `Type` and by string type name, to the Reflector's converter system. It introduces new methods for blacklisting multiple types at once, improves cache invalidation logic, and adds extensive unit tests to ensure correct behavior, including handling of nulls, duplicates, and derived types.

### Batch Blacklisting Functionality

* Added `BlacklistTypes(params Type[] types)` to allow blacklisting multiple types at once, with logic to ignore nulls, deduplicate, and only invalidate the cache if new types are added.
* Added `BlacklistTypes(params string[] typeFullNames)` and `BlacklistType(string typeFullName)` to allow blacklisting by string type names, resolving types using `TypeUtils.GetType`, and handling invalid names gracefully.
* Ensured that cache invalidation occurs only when the blacklist actually changes, improving performance for repeated or redundant calls.

### Unit Testing Enhancements

* Added a comprehensive set of unit tests covering batch blacklisting with both `Type` and string names, handling of nulls, empty arrays, duplicates, derived types, generic types, and cache invalidation.

### Utilities and Imports

* Added import of `com.IvanMurzak.ReflectorNet.Utils` to support type resolution by string name.