### PR TITLE
Handle JsonException in TryUnstringifyJson calls

### DIFF
--- a/ReflectorNet/src/Reflector/MethodWrapper.cs
+++ b/ReflectorNet/src/Reflector/MethodWrapper.cs
@@ -268,17 +268,10 @@ namespace com.IvanMurzak.ReflectorNet
                 if (!isPrimitive)
                 {
                     // Handle stringified json
-                    try
+                    if (JsonUtils.TryUnstringifyJson(jsonElement, out var unstringifiedJson))
                     {
-                        if (JsonUtils.TryUnstringifyJson(jsonElement, out var unstringifiedJson))
-                        {
-                            value = unstringifiedJson;
-                            jsonElement = unstringifiedJson!.Value;
-                        }
-                    }
-                    catch (JsonException)
-                    {
-                        // Ignore, value is not a stringified JSON
+                        value = unstringifiedJson;
+                        jsonElement = unstringifiedJson!.Value;
                     }
                 }
                 try
@@ -359,17 +352,10 @@ namespace com.IvanMurzak.ReflectorNet
                     if (!isPrimitive)
                     {
                         // Handle stringified json
-                        try
+                        if (JsonUtils.TryUnstringifyJson(jsonElement, out var unstringifiedJson))
                         {
-                            if (JsonUtils.TryUnstringifyJson(jsonElement, out var unstringifiedJson))
-                            {
-                                value = unstringifiedJson;
-                                jsonElement = unstringifiedJson!.Value;
-                            }
-                        }
-                        catch (JsonException)
-                        {
-                            // Ignore, value is not a stringified JSON
+                            value = unstringifiedJson;
+                            jsonElement = unstringifiedJson!.Value;
                         }
                     }
                     try

--- a/ReflectorNet/src/Utils/Json/JsonUtils.cs
+++ b/ReflectorNet/src/Utils/Json/JsonUtils.cs
@@ -16,9 +16,15 @@ namespace com.IvanMurzak.ReflectorNet.Utils
             if (jsonElement.ValueKind == JsonValueKind.String)
             {
                 var str = jsonElement.GetString() ?? string.Empty;
-
-                result = System.Text.Json.JsonSerializer.Deserialize<JsonElement>(str);
-                return true;
+                try
+                {
+                    result = System.Text.Json.JsonSerializer.Deserialize<JsonElement>(str);
+                    return true;
+                }
+                catch (JsonException)
+                {
+                    // Ignore, value is not a stringified JSON
+                }
             }
             result = null;
             return false;


### PR DESCRIPTION
Wrapped calls to JsonUtils.TryUnstringifyJson in try-catch blocks to handle potential JsonException and prevent crashes when input is not a stringified JSON. Also moved the file header comment in JsonUtils.cs outside the namespace for clarity.