### PR TITLE
feat: Generic type blacklisting and enhance blacklist checks in Reflector

### DIFF
--- a/ReflectorNet/src/Reflector/Reflector.Registry.cs
+++ b/ReflectorNet/src/Reflector/Reflector.Registry.cs
@@ -260,9 +260,18 @@ namespace com.IvanMurzak.ReflectorNet
                         return true;
                 }
 
-                // Check if it's a generic type and any type argument is blacklisted
+                // Check if it's a generic type
                 if (type.IsGenericType)
                 {
+                    // Check if the generic type definition is blacklisted (e.g., List<> blacklisted means List<int> is also blacklisted)
+                    if (!type.IsGenericTypeDefinition)
+                    {
+                        var genericDefinition = type.GetGenericTypeDefinition();
+                        if (_blacklistedTypes.ContainsKey(genericDefinition))
+                            return true;
+                    }
+
+                    // Check if any type argument is blacklisted
                     var genericArgs = type.GetGenericArguments();
                     for (int i = 0; i < genericArgs.Length; i++)
                     {


### PR DESCRIPTION
This pull request adds comprehensive tests for generic type blacklisting and extends the blacklisting logic in the `Reflector` class to support blacklisting generic type definitions. This ensures that when a generic type definition (like `List<>`) is blacklisted, all its closed constructed types (such as `List<int>`, `List<string>`, etc.) are also considered blacklisted. The changes also cover nested generics, arrays of generics, and .NET-specific types like `Span<>` and `ReadOnlySpan<>`.

**Generic Type Blacklisting Enhancements**

* Updated the internal logic in `Reflector.Registry.cs` to check if a generic type's definition is blacklisted, ensuring that blacklisting a generic type definition (e.g., `List<>`) will blacklist all its closed constructed types (e.g., `List<int>`, `List<string>`) as well.

**Expanded Unit Test Coverage**

* Added a new test region in `IsTypeBlacklistedTests.cs` for generic type definition blacklisting, including tests for blacklisting closed generic types, generic type definitions, nested generics, custom generic wrappers, arrays of generics, and .NET-specific generic types like `Span<>` and `ReadOnlySpan<>`.