### PR TITLE
refactor: simplify null handling in serialization methods across converters

### DIFF
--- a/ReflectorNet/src/Converter/Reflection/Base/BaseReflectionConverter.Serialize.cs
+++ b/ReflectorNet/src/Converter/Reflection/Base/BaseReflectionConverter.Serialize.cs
@@ -71,24 +71,24 @@ namespace com.IvanMurzak.ReflectorNet.Converter
                 {
                     if (logger?.IsEnabled(LogLevel.Trace) == true)
                         logger.LogTrace("{padding}Skipping serialization of field '{fieldName}' of type '{type}' in '{objType}' because its type is blacklisted.\nPath: {path}",
-                            StringUtils.GetPadding(depth + 1), field.Name, fieldType.GetTypeId(), objType.GetTypeId(), context?.GetPath(obj));
+                            StringUtils.GetPadding(depth), field.Name, fieldType.GetTypeId(), objType.GetTypeId(), context?.GetPath(obj));
                     continue;
                 }
                 try
                 {
                     if (logger?.IsEnabled(LogLevel.Trace) == true)
                         logger.LogTrace("{padding}Serializing field '{fieldName}' of type '{type}' in '{objType}'.\nPath: {path}",
-                            StringUtils.GetPadding(depth + 1), field.Name, fieldType.GetTypeId(), objType.GetTypeId(), context?.GetPath(obj));
+                            StringUtils.GetPadding(depth), field.Name, fieldType.GetTypeId(), objType.GetTypeId(), context?.GetPath(obj));
 
                     var value = field.GetValue(obj);
 
-                    var serialized = reflector.Serialize(
-                        obj: value,
-                        fallbackType: fieldType,
-                        name: field.Name,
-                        recursive: AllowCascadeFieldsConversion,
+                    var serialized = SerializeField(
+                        reflector: reflector,
+                        obj: obj,
+                        field: field,
+                        value: value,
                         flags: flags,
-                        depth: depth + 1,
+                        depth: depth,
                         logs: logs,
                         logger: logger,
                         context: context);
@@ -101,7 +101,7 @@ namespace com.IvanMurzak.ReflectorNet.Converter
                     // skip inaccessible field
                     if (logger?.IsEnabled(LogLevel.Warning) == true)
                         logger.LogWarning(ex.GetBaseException(), "{padding}Failed to serialize field '{fieldName}' of type '{type}' in '{objType}'. Converter: {converter}. Path: {path}",
-                             StringUtils.GetPadding(depth + 1), field.Name, fieldType.GetTypeId(), objType.GetTypeId(), GetType().GetTypeShortName(), context?.GetPath(obj));
+                             StringUtils.GetPadding(depth), field.Name, fieldType.GetTypeId(), objType.GetTypeId(), GetType().GetTypeShortName(), context?.GetPath(obj));
                 }
             }
             return serializedFields;
@@ -131,24 +131,24 @@ namespace com.IvanMurzak.ReflectorNet.Converter
                 {
                     if (logger?.IsEnabled(LogLevel.Trace) == true)
                         logger.LogTrace("{padding}Skipping serialization of property '{propertyName}' of type '{type}' in '{objType}' because its type is blacklisted.\nPath: {path}",
-                            StringUtils.GetPadding(depth + 1), prop.Name, propType.GetTypeId(), objType.GetTypeId(), context?.GetPath(obj));
+                            StringUtils.GetPadding(depth), prop.Name, propType.GetTypeId(), objType.GetTypeId(), context?.GetPath(obj));
                     continue;
                 }
                 try
                 {
                     if (logger?.IsEnabled(LogLevel.Trace) == true)
                         logger.LogTrace("{padding}Serializing property '{propertyName}' of type '{type}' in '{objType}'.\nPath: {path}",
-                            StringUtils.GetPadding(depth + 1), prop.Name, propType.GetTypeId(), objType.GetTypeId(), context?.GetPath(obj));
+                            StringUtils.GetPadding(depth), prop.Name, propType.GetTypeId(), objType.GetTypeId(), context?.GetPath(obj));
 
                     var value = prop.GetValue(obj);
 
-                    var serialized = reflector.Serialize(
-                        obj: value,
-                        fallbackType: propType,
-                        name: prop.Name,
-                        recursive: AllowCascadePropertiesConversion,
+                    var serialized = SerializeProperty(
+                        reflector: reflector,
+                        obj: obj,
+                        property: prop,
+                        value: value,
                         flags: flags,
-                        depth: depth + 1,
+                        depth: depth,
                         logs: logs,
                         logger: logger,
                         context: context);
@@ -161,7 +161,7 @@ namespace com.IvanMurzak.ReflectorNet.Converter
                     // skip inaccessible property
                     if (logger?.IsEnabled(LogLevel.Warning) == true)
                         logger.LogWarning(ex.GetBaseException(), "{padding}Failed to serialize property '{propertyName}' of type '{type}' in '{objType}'. Converter: {converter}. Path: {path}",
-                             StringUtils.GetPadding(depth + 1), prop.Name, propType.GetTypeId(), objType.GetTypeId(), GetType().GetTypeShortName(), context?.GetPath(obj));
+                             StringUtils.GetPadding(depth), prop.Name, propType.GetTypeId(), objType.GetTypeId(), GetType().GetTypeShortName(), context?.GetPath(obj));
                 }
             }
             return serializedProperties;
@@ -178,5 +178,51 @@ namespace com.IvanMurzak.ReflectorNet.Converter
             Logs? logs = null,
             ILogger? logger = null,
             SerializationContext? context = null);
+
+        protected virtual SerializedMember SerializeField(
+            Reflector reflector,
+            object obj,
+            FieldInfo field,
+            object? value,
+            BindingFlags flags,
+            int depth,
+            Logs? logs,
+            ILogger? logger,
+            SerializationContext? context)
+        {
+            return reflector.Serialize(
+                obj: value,
+                fallbackType: field.FieldType,
+                name: field.Name,
+                recursive: AllowCascadeFieldsConversion,
+                flags: flags,
+                depth: depth,
+                logs: logs,
+                logger: logger,
+                context: context);
+        }
+
+        protected virtual SerializedMember SerializeProperty(
+            Reflector reflector,
+            object obj,
+            PropertyInfo property,
+            object? value,
+            BindingFlags flags,
+            int depth,
+            Logs? logs,
+            ILogger? logger,
+            SerializationContext? context)
+        {
+            return reflector.Serialize(
+                obj: value,
+                fallbackType: property.PropertyType,
+                name: property.Name,
+                recursive: AllowCascadePropertiesConversion,
+                flags: flags,
+                depth: depth,
+                logs: logs,
+                logger: logger,
+                context: context);
+        }
     }
 }

--- a/ReflectorNet/src/Converter/Reflection/GenericReflectionConverter.cs
+++ b/ReflectorNet/src/Converter/Reflection/GenericReflectionConverter.cs
@@ -30,7 +30,7 @@ namespace com.IvanMurzak.ReflectorNet.Converter
             SerializationContext? context = null)
         {
             if (obj == null)
-                return SerializedMember.FromJson(type, json: null, name: name);
+                return SerializedMember.Null(type, name);
 
             var isStruct = type.IsValueType && !type.IsPrimitive && !type.IsEnum;
             if (type.IsClass || isStruct)
@@ -45,7 +45,7 @@ namespace com.IvanMurzak.ReflectorNet.Converter
                             reflector: reflector,
                             obj: obj,
                             flags: flags,
-                            depth: depth,
+                            depth: depth + 1,
                             logs: logs,
                             logger: logger,
                             context: context),
@@ -53,7 +53,7 @@ namespace com.IvanMurzak.ReflectorNet.Converter
                             reflector: reflector,
                             obj: obj,
                             flags: flags,
-                            depth: depth,
+                            depth: depth + 1,
                             logs: logs,
                             logger: logger,
                             context: context),

--- a/ReflectorNet/src/Converter/Reflection/PrimitiveReflectionConverter.cs
+++ b/ReflectorNet/src/Converter/Reflection/PrimitiveReflectionConverter.cs
@@ -39,7 +39,7 @@ namespace com.IvanMurzak.ReflectorNet.Converter
             SerializationContext? context = null)
         {
             if (obj == null)
-                return SerializedMember.FromJson(type, json: null, name: name);
+                return SerializedMember.Null(type, name);
 
             return SerializedMember.FromValue(reflector, type, obj, name: name);
         }


### PR DESCRIPTION
This pull request refactors and improves the serialization logic in the reflection-based converters. The main changes include introducing dedicated methods for field and property serialization, standardizing logging indentation, and updating how null values are handled. These updates enhance code clarity, maintainability, and consistency in serialization depth handling.

**Refactoring serialization logic:**

* Added `SerializeField` and `SerializeProperty` helper methods to `BaseReflectionConverter.Serialize.cs` for handling field and property serialization, replacing inline calls to `reflector.Serialize` in the main serialization loop.
* Updated calls in field and property serialization to use these new helper methods, and standardized the depth parameter to avoid incrementing it unnecessarily. [[1]](diffhunk://#diff-cc58cc46de7c4689304516dddee092dd5e8ec3ae802736457139e5c271355430L74-R91) [[2]](diffhunk://#diff-cc58cc46de7c4689304516dddee092dd5e8ec3ae802736457139e5c271355430L134-R151)

**Logging improvements:**

* Standardized logging indentation by passing `depth` instead of `depth + 1` to `StringUtils.GetPadding` in trace and warning log statements for both fields and properties. [[1]](diffhunk://#diff-cc58cc46de7c4689304516dddee092dd5e8ec3ae802736457139e5c271355430L74-R91) [[2]](diffhunk://#diff-cc58cc46de7c4689304516dddee092dd5e8ec3ae802736457139e5c271355430L104-R104) [[3]](diffhunk://#diff-cc58cc46de7c4689304516dddee092dd5e8ec3ae802736457139e5c271355430L134-R151) [[4]](diffhunk://#diff-cc58cc46de7c4689304516dddee092dd5e8ec3ae802736457139e5c271355430L164-R164)

**Null value handling:**

* Changed null serialization to use `SerializedMember.Null` instead of `SerializedMember.FromJson(..., json: null, ...)` in both `GenericReflectionConverter` and `PrimitiveReflectionConverter`. [[1]](diffhunk://#diff-0eff9d8f6f5e53f142e605aee48b2b3223cdc6f92372040e27df3e47367accf6L33-R33) [[2]](diffhunk://#diff-acc600b69847fe1839a30683eec30ff92b5f47d88d310c5541c963549aad95b1L42-R42)

**Depth handling in generic converter:**

* Updated the depth parameter when serializing fields and properties in `GenericReflectionConverter` to increment depth by 1, ensuring proper nesting in serialization.