### PR TITLE
chore: update package references for Microsoft.Extensions.Logging and System.Text.Json to version 10.0.3

### DIFF
--- a/ConsoleApp/ConsoleApp.csproj
+++ b/ConsoleApp/ConsoleApp.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
   </ItemGroup>
 
 </Project>

--- a/ReflectorNet.Tests.OuterAssembly/ReflectorNet.Tests.OuterAssembly.csproj
+++ b/ReflectorNet.Tests.OuterAssembly/ReflectorNet.Tests.OuterAssembly.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="10.0.1" />
+    <PackageReference Include="System.Text.Json" Version="10.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ReflectorNet.Tests/ReflectorNet.Tests.csproj
+++ b/ReflectorNet.Tests/ReflectorNet.Tests.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="System.Text.Json" Version="10.0.1" />
+    <PackageReference Include="System.Text.Json" Version="10.0.3" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>

--- a/ReflectorNet/ReflectorNet.csproj
+++ b/ReflectorNet/ReflectorNet.csproj
@@ -27,8 +27,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.1" />
-    <PackageReference Include="System.Text.Json" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.3" />
+    <PackageReference Include="System.Text.Json" Version="10.0.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This pull request updates several NuGet package dependencies across multiple project files to ensure consistency and take advantage of the latest bug fixes and improvements. The main focus is on upgrading `System.Text.Json` and `Microsoft.Extensions.Logging` packages to version 10.0.3.

Dependency upgrades:

* Upgraded `System.Text.Json` from version 10.0.1 to 10.0.3 in `ReflectorNet/ReflectorNet.csproj`, `ReflectorNet.Tests/ReflectorNet.Tests.csproj`, and `ReflectorNet.Tests.OuterAssembly/ReflectorNet.Tests.OuterAssembly.csproj` for improved reliability and compatibility. [[1]](diffhunk://#diff-d6a9fe4d6d4c157d7c8e9f4b624ccbc8616764e51a7662e35f7621b40fb5ddf3L30-R31) [[2]](diffhunk://#diff-98871e0b14515dcbc9191bd913e3c3b768c0dc9ca652be50cdbd5c198685be9aL15-R15) [[3]](diffhunk://#diff-1564514d2d3ec4756eca536f2192dfc02144d87e733e9953ff06b7950d06a3e0L11-R11)
* Upgraded `Microsoft.Extensions.Logging` and `Microsoft.Extensions.Logging.Console` from version 10.0.1 to 10.0.3 in `ReflectorNet/ReflectorNet.csproj` and `ConsoleApp/ConsoleApp.csproj` to ensure logging features are up to date. [[1]](diffhunk://#diff-d6a9fe4d6d4c157d7c8e9f4b624ccbc8616764e51a7662e35f7621b40fb5ddf3L30-R31) [[2]](diffhunk://#diff-96073d8f150150240a5e4f736962e9f69d032b5992a21a26200ca39c9fc86488L17-R17)