### PR TITLE
Add View and TryReadAt methods for object serialization enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Traditional reflection is brittle and requires exact matches. ReflectorNet is bu
 *   **🔄 In-Place Modification**: Update existing object instances from serialized data without breaking references.
 *   **🎯 Atomic Path-Based Modification**: Navigate directly to any field, array element, or dictionary entry by path and modify only that — without touching anything else.
 *   **🩹 JSON Patch**: Apply a JSON document to modify multiple fields at different depths in a single call, following JSON Merge Patch (RFC 7396) semantics.
+*   **🔎 View & Grep**: Read exactly what you need — navigate to a subtree, filter by name pattern or type, or grep the entire live object graph for all fields matching a regex. The read-side counterpart to path-based modification.
 *   **📄 JSON Schema Generation**: Automatically generate schemas for your types and methods to feed into LLM context windows.
 
 ## 📦 Installation
@@ -187,7 +188,134 @@ using var doc = JsonDocument.Parse(@"{ ""globalOrbitSpeedMultiplier"": 9.0 }");
 reflector.TryPatch(ref system, doc.RootElement, logs: logs);
 ```
 
-### 7. Dynamic Method Invocation
+### 7. View & Grep — Read-Side Navigation
+
+Read exactly the data you need from a live object — navigate to a specific subtree, filter by name or type, or grep the entire graph for every field matching a pattern.
+This is the read-side counterpart to [Atomic Path-Based Modification](#5-atomic-path-based-modification).
+
+---
+
+#### `reflector.View` — filtered serialization
+
+Returns a `SerializedMember` tree with optional path navigation and post-filters applied.
+
+```csharp
+var reflector = new Reflector();
+object? system = new SolarSystem
+{
+    globalOrbitSpeedMultiplier = 1f,
+    globalSizeMultiplier       = 2f,
+    celestialBodies = new[]
+    {
+        new CelestialBody { orbitRadius = 10f, orbitSpeed = 1f },
+        new CelestialBody { orbitRadius = 20f, orbitSpeed = 2f },
+    }
+};
+
+// Full view — equivalent to Serialize()
+SerializedMember? full = reflector.View(system);
+
+// Navigate to a subtree (same path format as TryModifyAt)
+SerializedMember? firstBody = reflector.View(system,
+    new ViewQuery { Path = "celestialBodies/[0]" });
+// firstBody.typeName contains "CelestialBody"
+
+// Depth-limited — MaxDepth=0 returns root node only (no children)
+SerializedMember? shallow = reflector.View(system,
+    new ViewQuery { MaxDepth = 1 });
+
+// Pattern filter — keep only branches containing a matching field name
+// Accepts any .NET regex; matching is case-insensitive
+SerializedMember? orbitFields = reflector.View(system,
+    new ViewQuery { NamePattern = "^orbit" });
+
+// Type filter — keep only branches whose resolved type is assignable to float
+SerializedMember? floatFields = reflector.View(system,
+    new ViewQuery { TypeFilter = typeof(float) });
+
+// Combined — navigate first, then filter
+SerializedMember? result = reflector.View(system, new ViewQuery
+{
+    Path        = "celestialBodies/[0]",
+    NamePattern = "^orbit",
+    MaxDepth    = 2,
+});
+```
+
+When a filter produces no matches the **root envelope is still returned** with an empty fields collection so that `result.typeName` always identifies the navigated node's type.
+
+**`ViewQuery` options:**
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `Path` | `string?` | `null` | Navigate to this path before serializing (same format as `TryModifyAt`) |
+| `MaxDepth` | `int?` | `null` | Maximum depth of returned tree (`0` = root node only, no children) |
+| `NamePattern` | `string?` | `null` | .NET regex matched against field / property names (case-insensitive) |
+| `TypeFilter` | `Type?` | `null` | Keep only branches whose resolved runtime type is assignable to this type |
+
+---
+
+#### `reflector.TryReadAt` — single-value path read
+
+Navigate to exactly one value by path and serialize it. Mirrors `TryModifyAt` but reads instead of writes.
+
+```csharp
+// Scalar leaf
+bool ok = reflector.TryReadAt(system, "celestialBodies/[0]/orbitRadius", out SerializedMember? r);
+if (ok)
+    Console.WriteLine(r!.GetValue<float>(reflector)); // 10f
+
+// Composite node — result has full fields tree for the navigated object
+reflector.TryReadAt(system, "celestialBodies/[0]", out var body);
+float radius = body!.fields!.First(f => f.name == "orbitRadius").GetValue<float>(reflector);
+
+// Dictionary access — string or any key type
+reflector.TryReadAt(container, "config/[timeout]", out var timeout);
+int ms = timeout!.GetValue<int>(reflector); // 30
+
+// Invalid paths return false; errors are collected in Logs — nothing is thrown
+var logs = new Logs();
+bool ok2 = reflector.TryReadAt(system, "doesNotExist", out _, logs: logs);
+// ok2 == false
+// logs: "Segment 'doesNotExist' not found on type 'SolarSystem'.
+//        Available fields: globalOrbitSpeedMultiplier, celestialBodies, ..."
+```
+
+---
+
+#### `reflector.Grep` — grep the live object graph
+
+Walks the entire live object graph and returns a flat list of every field / property whose name matches the given regex pattern — like the `grep` command, but for in-RAM objects.
+
+```csharp
+// Find every field whose name starts with "orbit"
+IReadOnlyList<ViewMatch> hits = reflector.Grep(system, "^orbit");
+
+foreach (var hit in hits)
+    Console.WriteLine($"{hit.Path} = {hit.Value.GetValue<float>(reflector)}");
+// celestialBodies/[0]/orbitRadius = 10
+// celestialBodies/[0]/orbitSpeed  = 1
+// celestialBodies/[1]/orbitRadius = 20
+// celestialBodies/[1]/orbitSpeed  = 2
+
+// Limit search depth (0 = top-level fields only, no recursion)
+IReadOnlyList<ViewMatch> topLevel = reflector.Grep(system, ".*", maxDepth: 0);
+
+// Exact name — anchored regex
+IReadOnlyList<ViewMatch> exact = reflector.Grep(system, "^globalOrbitSpeedMultiplier$");
+Console.WriteLine(exact[0].Path);  // "globalOrbitSpeedMultiplier"
+```
+
+Each `ViewMatch` exposes:
+
+* `Path` — full slash-delimited path, e.g. `"celestialBodies/[0]/orbitRadius"`
+* `Value` — `SerializedMember` of the matched field, ready for `GetValue<T>(reflector)`
+
+> **Grep vs. View + NamePattern**: `Grep` walks the **live object graph** and can find fields inside array elements. `View` + `NamePattern` filters the `SerializedMember` tree after serialization; array element contents are stored as JSON and are not individually filterable by name. Use `Grep` when you need to search inside arrays.
+
+---
+
+### 8. Dynamic Method Invocation
 
 Allow AI to find and call methods without knowing the exact signature.
 
@@ -218,7 +346,7 @@ string result = reflector.MethodCall(
 Console.WriteLine(result); // Output: [Success] 30
 ```
 
-### 6. Method Inspection & Schema Generation
+### 9. Method Inspection & Schema Generation
 
 Generate JSON schemas for types and methods to help LLMs understand your code structure.
 

--- a/ReflectorNet.Tests/src/ReflectorTests/ViewTests.cs
+++ b/ReflectorNet.Tests/src/ReflectorTests/ViewTests.cs
@@ -1,0 +1,465 @@
+using System.Collections.Generic;
+using System.Linq;
+using com.IvanMurzak.ReflectorNet.Model;
+using com.IvanMurzak.ReflectorNet.Tests.Model;
+using Xunit.Abstractions;
+
+namespace com.IvanMurzak.ReflectorNet.Tests.ReflectorTests
+{
+    public class ViewTests : BaseTest
+    {
+        public ViewTests(ITestOutputHelper output) : base(output) { }
+
+        // ─── View — default (no query) ────────────────────────────────────────────
+
+        [Fact]
+        public void View_Default_MatchesSerialize()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem
+            {
+                globalOrbitSpeedMultiplier = 2f,
+                globalSizeMultiplier = 3f,
+                celestialBodies = new[]
+                {
+                    new SolarSystem.CelestialBody { orbitRadius = 10f, orbitSpeed = 1f }
+                }
+            };
+            object? obj = system;
+
+            var viewed = reflector.View(obj);
+            var serialized = reflector.Serialize(system);
+
+            Assert.NotNull(viewed);
+            Assert.Equal(serialized.typeName, viewed.typeName);
+            Assert.NotNull(viewed.fields);
+            Assert.Equal(serialized.fields?.Count, viewed.fields?.Count);
+        }
+
+        // ─── View — Path navigates to subtree ────────────────────────────────────
+
+        [Fact]
+        public void View_Path_ReturnsSubTree()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem
+            {
+                celestialBodies = new[]
+                {
+                    new SolarSystem.CelestialBody { orbitRadius = 42f, orbitSpeed = 7f },
+                    new SolarSystem.CelestialBody { orbitRadius = 99f, orbitSpeed = 9f },
+                }
+            };
+            object? obj = system;
+
+            var result = reflector.View(obj, new ViewQuery { Path = "celestialBodies/[0]" });
+
+            Assert.NotNull(result);
+            // Should have typeName of CelestialBody
+            Assert.Contains("CelestialBody", result.typeName);
+            // Should NOT contain data from [1]
+            var orbitRadius = result.fields?.FirstOrDefault(f => f.name == "orbitRadius");
+            Assert.NotNull(orbitRadius);
+            Assert.Equal(42f, orbitRadius.GetValue<float>(reflector));
+        }
+
+        // ─── View — MaxDepth = 0 strips all children ─────────────────────────────
+
+        [Fact]
+        public void View_MaxDepth_Zero_RootOnly()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem { globalOrbitSpeedMultiplier = 1f };
+            object? obj = system;
+
+            var result = reflector.View(obj, new ViewQuery { MaxDepth = 0 });
+
+            Assert.NotNull(result);
+            Assert.Contains("SolarSystem", result.typeName);
+            Assert.True(result.fields == null || result.fields.Count == 0,
+                "MaxDepth=0 should strip all nested fields");
+        }
+
+        // ─── View — MaxDepth = 1 keeps top-level fields, strips their children ───
+
+        [Fact]
+        public void View_MaxDepth_One_TopLevel()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem
+            {
+                celestialBodies = new[]
+                {
+                    new SolarSystem.CelestialBody { orbitRadius = 5f }
+                }
+            };
+            object? obj = system;
+
+            var result = reflector.View(obj, new ViewQuery { MaxDepth = 1 });
+
+            Assert.NotNull(result);
+            // celestialBodies field should be present ...
+            var bodiesField = result.fields?.FirstOrDefault(f => f.name == "celestialBodies");
+            Assert.NotNull(bodiesField);
+            // ... but its own fields should be stripped (MaxDepth=1 means children of root are visible, grandchildren stripped)
+            // The array element [0] field should have no further fields
+            var elem0 = bodiesField.fields?.FirstOrDefault();
+            if (elem0 != null)
+                Assert.True(elem0.fields == null || elem0.fields.Count == 0,
+                    "MaxDepth=1 means grandchildren are stripped");
+        }
+
+        // ─── View — NamePattern keeps only matching direct fields ────────────────
+        // Note: NamePattern filters the SerializedMember tree (fields/props).
+        // Array elements stored in valueJsonElement are not individually filterable via NamePattern;
+        // use Grep for deep pattern search across the live object graph.
+
+        [Fact]
+        public void View_NamePattern_SparseTree()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem
+            {
+                globalOrbitSpeedMultiplier = 2f,
+                globalSizeMultiplier = 3f,
+            };
+            object? obj = system;
+
+            // "globalOrbit" (contains match, case-insensitive regex) matches globalOrbitSpeedMultiplier
+            // but not globalSizeMultiplier, sun, or celestialBodies
+            var result = reflector.View(obj, new ViewQuery { NamePattern = "globalOrbit" });
+
+            Assert.NotNull(result);
+            // globalOrbitSpeedMultiplier should be present
+            var orbitField = result.fields?.FirstOrDefault(f => f.name == "globalOrbitSpeedMultiplier");
+            Assert.NotNull(orbitField);
+            // globalSizeMultiplier should be pruned (does not match "globalOrbit")
+            Assert.True(result.fields == null || result.fields.All(f => f.name != "globalSizeMultiplier"),
+                "globalSizeMultiplier should be pruned");
+        }
+
+        // ─── View — NamePattern with no matches returns root envelope ─────────────
+
+        [Fact]
+        public void View_NamePattern_NoMatch_EmptyEnvelope()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem { globalOrbitSpeedMultiplier = 1f };
+            object? obj = system;
+
+            var result = reflector.View(obj, new ViewQuery { NamePattern = "doesNotMatchAnything_xyz" });
+
+            Assert.NotNull(result);
+            Assert.Contains("SolarSystem", result.typeName);
+            Assert.True(result.fields == null || result.fields.Count == 0,
+                "No matching fields → empty envelope");
+        }
+
+        // ─── View — combined Path + NamePattern ───────────────────────────────────
+
+        [Fact]
+        public void View_CombinedPathAndPattern()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem
+            {
+                celestialBodies = new[]
+                {
+                    new SolarSystem.CelestialBody { orbitRadius = 7f, orbitSpeed = 2f, rotationSpeed = 9f }
+                }
+            };
+            object? obj = system;
+
+            // Navigate to [0] then filter by "^orbit"
+            var result = reflector.View(obj, new ViewQuery { Path = "celestialBodies/[0]", NamePattern = "^orbit" });
+
+            Assert.NotNull(result);
+            Assert.Contains("CelestialBody", result.typeName);
+            Assert.NotNull(result.fields);
+            Assert.True(result.fields.All(f => f.name == null || f.name.StartsWith("orbit")),
+                "Only orbit* fields should remain after pattern filter");
+            Assert.True(result.fields.All(f => f.name != "rotationSpeed"),
+                "rotationSpeed should be pruned");
+        }
+
+        // ─── TryReadAt — root field ───────────────────────────────────────────────
+
+        [Fact]
+        public void TryReadAt_RootField()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem { globalOrbitSpeedMultiplier = 5f };
+            object? obj = system;
+
+            var ok = reflector.TryReadAt(obj, "globalOrbitSpeedMultiplier", out var result);
+
+            Assert.True(ok);
+            Assert.NotNull(result);
+            Assert.Equal(5f, result.GetValue<float>(reflector));
+        }
+
+        // ─── TryReadAt — array element ────────────────────────────────────────────
+
+        [Fact]
+        public void TryReadAt_ArrayElement()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem
+            {
+                celestialBodies = new[]
+                {
+                    new SolarSystem.CelestialBody { orbitRadius = 10f, orbitSpeed = 3f },
+                    new SolarSystem.CelestialBody { orbitRadius = 20f, orbitSpeed = 4f },
+                }
+            };
+            object? obj = system;
+
+            var ok = reflector.TryReadAt(obj, "celestialBodies/[0]", out var result);
+
+            Assert.True(ok);
+            Assert.NotNull(result);
+            Assert.Contains("CelestialBody", result.typeName);
+            var orbitRadius = result.fields?.FirstOrDefault(f => f.name == "orbitRadius");
+            Assert.NotNull(orbitRadius);
+            Assert.Equal(10f, orbitRadius.GetValue<float>(reflector));
+        }
+
+        // ─── TryReadAt — nested field ─────────────────────────────────────────────
+
+        [Fact]
+        public void TryReadAt_NestedField()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem
+            {
+                celestialBodies = new[]
+                {
+                    new SolarSystem.CelestialBody { orbitRadius = 42f }
+                }
+            };
+            object? obj = system;
+
+            var ok = reflector.TryReadAt(obj, "celestialBodies/[0]/orbitRadius", out var result);
+
+            Assert.True(ok);
+            Assert.NotNull(result);
+            Assert.Equal(42f, result.GetValue<float>(reflector));
+        }
+
+        // ─── TryReadAt — dictionary string key ───────────────────────────────────
+
+        [Fact]
+        public void TryReadAt_DictionaryStringKey()
+        {
+            var reflector = new Reflector();
+            var container = new DictionaryContainer
+            {
+                config = new Dictionary<string, int> { ["timeout"] = 30, ["retries"] = 5 }
+            };
+            object? obj = container;
+
+            var ok = reflector.TryReadAt(obj, "config/[timeout]", out var result);
+
+            Assert.True(ok);
+            Assert.NotNull(result);
+            Assert.Equal(30, result.GetValue<int>(reflector));
+        }
+
+        // ─── TryReadAt — dictionary integer key ──────────────────────────────────
+
+        [Fact]
+        public void TryReadAt_DictionaryIntKey()
+        {
+            var reflector = new Reflector();
+            var container = new IntDictionaryContainer
+            {
+                lookup = new Dictionary<int, string> { [1] = "one", [2] = "two" }
+            };
+            object? obj = container;
+
+            var ok = reflector.TryReadAt(obj, "lookup/[2]", out var result);
+
+            Assert.True(ok);
+            Assert.NotNull(result);
+            Assert.Equal("two", result.GetValue<string>(reflector));
+        }
+
+        // ─── TryReadAt — invalid path returns false + logs ────────────────────────
+
+        [Fact]
+        public void TryReadAt_InvalidPath_ReturnsFalse()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem { globalOrbitSpeedMultiplier = 1f };
+            object? obj = system;
+            var logs = new Logs();
+
+            var ok = reflector.TryReadAt(obj, "doesNotExist", out var result, logs: logs);
+
+            Assert.False(ok);
+            Assert.Null(result);
+            var logsText = logs.ToString();
+            _output.WriteLine(logsText);
+            Assert.Contains("doesNotExist", logsText);
+            Assert.Contains("not found", logsText);
+        }
+
+        // ─── TryReadAt — out-of-bounds index returns false + logs ────────────────
+
+        [Fact]
+        public void TryReadAt_OutOfBounds_ReturnsFalse()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem
+            {
+                celestialBodies = new[]
+                {
+                    new SolarSystem.CelestialBody { orbitRadius = 1f }
+                }
+            };
+            object? obj = system;
+            var logs = new Logs();
+
+            var ok = reflector.TryReadAt(obj, "celestialBodies/[99]", out var result, logs: logs);
+
+            Assert.False(ok);
+            Assert.Null(result);
+            var logsText = logs.ToString();
+            _output.WriteLine(logsText);
+            Assert.Contains("[99]", logsText);
+            Assert.Contains("out of range", logsText);
+        }
+
+        // ─── Grep — simple pattern finds all matches ──────────────────────────────
+
+        [Fact]
+        public void Grep_SimplePattern_FindsAllMatches()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem
+            {
+                celestialBodies = new[]
+                {
+                    new SolarSystem.CelestialBody { orbitRadius = 10f, orbitSpeed = 1f },
+                    new SolarSystem.CelestialBody { orbitRadius = 20f, orbitSpeed = 2f },
+                }
+            };
+            object? obj = system;
+
+            var matches = reflector.Grep(obj, "^orbit");
+
+            _output.WriteLine($"Found {matches.Count} matches:");
+            foreach (var m in matches)
+                _output.WriteLine($"  {m.Path}");
+
+            Assert.True(matches.Count >= 4, "Expected at least orbitRadius and orbitSpeed for each of 2 bodies");
+            Assert.Contains(matches, m => m.Path.Contains("orbitRadius"));
+            Assert.Contains(matches, m => m.Path.Contains("orbitSpeed"));
+        }
+
+        // ─── Grep — maxDepth limits search ───────────────────────────────────────
+
+        [Fact]
+        public void Grep_MaxDepth_LimitsSearch()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem
+            {
+                globalOrbitSpeedMultiplier = 1f,
+                celestialBodies = new[]
+                {
+                    new SolarSystem.CelestialBody { orbitRadius = 10f }
+                }
+            };
+            object? obj = system;
+
+            // maxDepth=0 — only top-level fields of SolarSystem
+            var matchesDepth0 = reflector.Grep(obj, ".*", maxDepth: 0);
+            _output.WriteLine($"maxDepth=0 found {matchesDepth0.Count} matches");
+            foreach (var m in matchesDepth0)
+                _output.WriteLine($"  {m.Path}");
+
+            // Should include globalOrbitSpeedMultiplier, globalSizeMultiplier, sun, celestialBodies
+            // But NOT fields inside celestialBodies elements (those are at depth 2+)
+            Assert.True(matchesDepth0.All(m => !m.Path.Contains("/")),
+                "maxDepth=0 should return only root-level fields (no slashes in path)");
+        }
+
+        // ─── Grep — array elements found ─────────────────────────────────────────
+
+        [Fact]
+        public void Grep_ArrayElements_FindsMatches()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem
+            {
+                celestialBodies = new[]
+                {
+                    new SolarSystem.CelestialBody { orbitRadius = 10f },
+                    new SolarSystem.CelestialBody { orbitRadius = 20f },
+                    new SolarSystem.CelestialBody { orbitRadius = 30f },
+                }
+            };
+            object? obj = system;
+
+            var matches = reflector.Grep(obj, "^orbitRadius$");
+
+            _output.WriteLine($"Found {matches.Count} orbitRadius matches:");
+            foreach (var m in matches)
+                _output.WriteLine($"  {m.Path} = {m.Value.GetValue<float>(reflector)}");
+
+            Assert.Equal(3, matches.Count);
+            Assert.Contains(matches, m => m.Path.Contains("[0]") && m.Value.GetValue<float>(reflector) == 10f);
+            Assert.Contains(matches, m => m.Path.Contains("[1]") && m.Value.GetValue<float>(reflector) == 20f);
+            Assert.Contains(matches, m => m.Path.Contains("[2]") && m.Value.GetValue<float>(reflector) == 30f);
+        }
+
+        // ─── Grep — no matches returns empty list ─────────────────────────────────
+
+        [Fact]
+        public void Grep_NoMatches_ReturnsEmpty()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem { globalOrbitSpeedMultiplier = 1f };
+            object? obj = system;
+
+            var matches = reflector.Grep(obj, "thisFieldDoesNotExist_xyz");
+
+            Assert.Empty(matches);
+        }
+
+        // ─── Grep — dictionary field found ───────────────────────────────────────
+
+        [Fact]
+        public void Grep_DictionaryField_Found()
+        {
+            var reflector = new Reflector();
+            var container = new DictionaryContainer
+            {
+                config = new Dictionary<string, int> { ["timeout"] = 10 }
+            };
+            object? obj = container;
+
+            var matches = reflector.Grep(obj, "^config$");
+
+            _output.WriteLine($"Found {matches.Count} matches:");
+            foreach (var m in matches)
+                _output.WriteLine($"  {m.Path}");
+
+            Assert.True(matches.Count >= 1);
+            Assert.Contains(matches, m => m.Path == "config");
+        }
+
+        // ─── Test-local helper types ───────────────────────────────────────────────
+
+        private class DictionaryContainer
+        {
+            public Dictionary<string, int> config = new Dictionary<string, int>();
+        }
+
+        private class IntDictionaryContainer
+        {
+            public Dictionary<int, string> lookup = new Dictionary<int, string>();
+        }
+    }
+}

--- a/ReflectorNet.Tests/src/ReflectorTests/ViewTests.cs
+++ b/ReflectorNet.Tests/src/ReflectorTests/ViewTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using com.IvanMurzak.ReflectorNet.Model;
@@ -448,6 +449,45 @@ namespace com.IvanMurzak.ReflectorNet.Tests.ReflectorTests
 
             Assert.True(matches.Count >= 1);
             Assert.Contains(matches, m => m.Path == "config");
+        }
+
+        // ─── View — TypeFilter keeps only matching type branches ─────────────────
+
+        [Fact]
+        public void View_TypeFilter_KeepsMatchingBranches()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem
+            {
+                globalOrbitSpeedMultiplier = 2f,
+                globalSizeMultiplier = 3f,
+            };
+            object? obj = system;
+
+            // TypeFilter = float should keep only float fields and discard non-float ones
+            var result = reflector.View(obj, new ViewQuery { TypeFilter = typeof(float) });
+
+            Assert.NotNull(result);
+            // All returned fields/props must resolve to float
+            if (result.fields != null)
+                Assert.True(result.fields.All(f => f.typeName != null && f.typeName.Contains("Single") || f.typeName == "float"),
+                    "Only float fields should survive TypeFilter=float");
+        }
+
+        [Fact]
+        public void View_TypeFilter_NoMatch_EmptyEnvelope()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem { globalOrbitSpeedMultiplier = 1f };
+            object? obj = system;
+
+            // Nothing in SolarSystem resolves to Guid
+            var result = reflector.View(obj, new ViewQuery { TypeFilter = typeof(Guid) });
+
+            Assert.NotNull(result);
+            Assert.Contains("SolarSystem", result.typeName);
+            Assert.True(result.fields == null || result.fields.Count == 0,
+                "No matching type → empty envelope");
         }
 
         // ─── Test-local helper types ───────────────────────────────────────────────

--- a/ReflectorNet/src/Model/ViewQuery.cs
+++ b/ReflectorNet/src/Model/ViewQuery.cs
@@ -1,0 +1,75 @@
+/*
+ * ReflectorNet
+ * Author: Ivan Murzak (https://github.com/IvanMurzak)
+ * Copyright (c) 2025 Ivan Murzak
+ * Licensed under the Apache License, Version 2.0. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+
+namespace com.IvanMurzak.ReflectorNet.Model
+{
+    /// <summary>
+    /// Options for <see cref="Reflector.View"/> — controls which parts of the serialized data to return.
+    /// When no options are set, <c>View</c> is equivalent to <c>Serialize</c> (full tree returned).
+    /// </summary>
+    public class ViewQuery
+    {
+        /// <summary>
+        /// Navigate to this path first, then serialize only that subtree.
+        /// Uses the same format as TryReadAt / TryModifyAt:
+        ///   - Plain segment navigates a field or property (e.g. "admin/name")
+        ///   - [i] navigates an Array or IList element (e.g. "users/[2]/name")
+        ///   - [key] navigates a dictionary entry (e.g. "config/[timeout]")
+        ///   - Leading "#/" is stripped automatically (compatible with SerializationContext paths)
+        /// </summary>
+        public string? Path { get; set; }
+
+        /// <summary>
+        /// .NET regex pattern applied to field/property names (case-insensitive).
+        /// Only branches that contain at least one matching name are kept in the result tree.
+        /// A plain string like "orbitRadius" matches that name exactly; "orbit.*" matches all
+        /// field/property names that start with "orbit".
+        /// When no match is found anywhere, the root envelope is returned with empty fields/props
+        /// so that the caller can still inspect the root type.
+        /// </summary>
+        public string? NamePattern { get; set; }
+
+        /// <summary>
+        /// Maximum depth of the returned tree.
+        /// 0 = root typeName/value only — no nested fields or properties.
+        /// 1 = one level of fields/props visible, their children stripped.
+        /// null = unlimited depth (default).
+        /// </summary>
+        public int? MaxDepth { get; set; }
+
+        /// <summary>
+        /// When set, only members whose resolved typeName is assignable to this type are kept.
+        /// Non-matching branches are pruned; the root envelope is preserved even with no matches.
+        /// </summary>
+        public Type? TypeFilter { get; set; }
+    }
+
+    /// <summary>
+    /// A single result entry returned by <see cref="Reflector.Grep"/>.
+    /// Holds the full slash-delimited path to the matched field/property and its serialized value.
+    /// </summary>
+    public class ViewMatch
+    {
+        /// <summary>
+        /// Full path to the matched location, e.g. "celestialBodies/[0]/orbitRadius".
+        /// </summary>
+        public string Path { get; }
+
+        /// <summary>
+        /// Serialized value at the matched location.
+        /// </summary>
+        public SerializedMember Value { get; }
+
+        public ViewMatch(string path, SerializedMember value)
+        {
+            Path  = path;
+            Value = value;
+        }
+    }
+}

--- a/ReflectorNet/src/Model/ViewQuery.cs
+++ b/ReflectorNet/src/Model/ViewQuery.cs
@@ -6,6 +6,7 @@
  */
 
 using System;
+using System.ComponentModel;
 
 namespace com.IvanMurzak.ReflectorNet.Model
 {
@@ -23,6 +24,13 @@ namespace com.IvanMurzak.ReflectorNet.Model
         ///   - [key] navigates a dictionary entry (e.g. "config/[timeout]")
         ///   - Leading "#/" is stripped automatically (compatible with SerializationContext paths)
         /// </summary>
+        [Description(
+            "Navigate to this path first, then serialize only that subtree. " +
+            "Path segments are separated by '/'. " +
+            "Use '[i]' for array/list index (e.g. 'users/[2]/name') and '[key]' for dictionary entry (e.g. 'config/[timeout]'). " +
+            "A leading '#/' is stripped automatically. " +
+            "Examples: 'admin/name', 'users/[0]/email', 'config/[timeout]'. " +
+            "Leave null to start from the root object.")]
         public string? Path { get; set; }
 
         /// <summary>
@@ -33,6 +41,12 @@ namespace com.IvanMurzak.ReflectorNet.Model
         /// When no match is found anywhere, the root envelope is returned with empty fields/props
         /// so that the caller can still inspect the root type.
         /// </summary>
+        [Description(
+            "Case-insensitive .NET regex pattern matched against field and property names. " +
+            "Only branches containing at least one match are kept in the result tree. " +
+            "Examples: 'orbitRadius' (exact name), 'orbit.*' (prefix match), 'radius|speed' (either name). " +
+            "When nothing matches, the root envelope is returned with empty fields/props. " +
+            "Leave null to return all fields and properties without filtering.")]
         public string? NamePattern { get; set; }
 
         /// <summary>
@@ -41,12 +55,23 @@ namespace com.IvanMurzak.ReflectorNet.Model
         /// 1 = one level of fields/props visible, their children stripped.
         /// null = unlimited depth (default).
         /// </summary>
+        [Description(
+            "Maximum nesting depth of the returned serialized tree. " +
+            "0 = root type name and value only — no nested fields or properties. " +
+            "1 = one level of fields/props visible, their children stripped. " +
+            "2 = two levels visible, and so on. " +
+            "Leave null (default) for unlimited depth.")]
         public int? MaxDepth { get; set; }
 
         /// <summary>
         /// When set, only members whose resolved typeName is assignable to this type are kept.
         /// Non-matching branches are pruned; the root envelope is preserved even with no matches.
         /// </summary>
+        [Description(
+            "When set, prunes the result tree to members whose runtime type is assignable to this type. " +
+            "Non-matching branches are removed; the root envelope is always preserved. " +
+            "Examples: typeof(float) keeps only float fields, typeof(IEnumerable) keeps only collections. " +
+            "Leave null to include members of any type.")]
         public Type? TypeFilter { get; set; }
     }
 
@@ -59,11 +84,16 @@ namespace com.IvanMurzak.ReflectorNet.Model
         /// <summary>
         /// Full path to the matched location, e.g. "celestialBodies/[0]/orbitRadius".
         /// </summary>
+        [Description(
+            "Full slash-delimited path to the matched location within the object graph. " +
+            "Array elements use bracket notation. " +
+            "Examples: 'orbitRadius', 'celestialBodies/[0]/orbitRadius', 'config/[timeout]'.")]
         public string Path { get; }
 
         /// <summary>
         /// Serialized value at the matched location.
         /// </summary>
+        [Description("Serialized representation of the value found at the matched path.")]
         public SerializedMember Value { get; }
 
         public ViewMatch(string path, SerializedMember value)

--- a/ReflectorNet/src/Reflector/Reflector.ReadAt.cs
+++ b/ReflectorNet/src/Reflector/Reflector.ReadAt.cs
@@ -63,7 +63,7 @@ namespace com.IvanMurzak.ReflectorNet
         /// <paramref name="objType"/> to the value at that segment.
         /// Handles bracket notation ([i] for arrays/lists, [key] for dicts) and plain member names.
         /// </summary>
-        internal bool TryNavigateOneSegment(
+        private bool TryNavigateOneSegment(
             ref object? obj,
             ref Type? objType,
             string segment,

--- a/ReflectorNet/src/Reflector/Reflector.ReadAt.cs
+++ b/ReflectorNet/src/Reflector/Reflector.ReadAt.cs
@@ -1,0 +1,196 @@
+/*
+ * ReflectorNet
+ * Author: Ivan Murzak (https://github.com/IvanMurzak)
+ * Copyright (c) 2025 Ivan Murzak
+ * Licensed under the Apache License, Version 2.0. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections;
+using System.Linq;
+using System.Reflection;
+using com.IvanMurzak.ReflectorNet.Model;
+using com.IvanMurzak.ReflectorNet.Utils;
+using Microsoft.Extensions.Logging;
+
+namespace com.IvanMurzak.ReflectorNet
+{
+    public partial class Reflector
+    {
+        /// <summary>
+        /// Navigates to a specific field, array element, or dictionary entry by path and
+        /// serializes only that target — the read-side counterpart of TryModifyAt.
+        ///
+        /// Path format:
+        ///   - Plain segment: field or property name (e.g. "admin" or "admin/name")
+        ///   - [i] where obj is Array/IList: array index (e.g. "users/[2]/name")
+        ///   - [key] where obj is IDictionary: dictionary key (e.g. "config/[timeout]")
+        ///   - Leading "#/" stripped automatically (compatible with SerializationContext paths)
+        ///
+        /// Errors are accumulated in the optional Logs object; nothing is thrown.
+        /// </summary>
+        public bool TryReadAt(
+            object? obj,
+            string path,
+            out SerializedMember? result,
+            Type? fallbackObjType = null,
+            int depth = 0,
+            Logs? logs = null,
+            BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+            ILogger? logger = null)
+        {
+            var segments   = ParsePath(path);
+            var target     = obj;
+            var targetType = obj?.GetType() ?? fallbackObjType;
+
+            for (int i = 0; i < segments.Length; i++)
+            {
+                if (!TryNavigateOneSegment(ref target, ref targetType, segments[i], depth + i, logs, flags, logger))
+                {
+                    result = null;
+                    return false;
+                }
+            }
+
+            result = Serialize(target, targetType, depth: depth + segments.Length, logs: logs, flags: flags, logger: logger);
+            return true;
+        }
+
+        // ─── Shared path-navigation helper (used by TryReadAt and View) ───────────────
+
+        /// <summary>
+        /// Navigates one path segment in-place, updating <paramref name="obj"/> and
+        /// <paramref name="objType"/> to the value at that segment.
+        /// Handles bracket notation ([i] for arrays/lists, [key] for dicts) and plain member names.
+        /// </summary>
+        internal bool TryNavigateOneSegment(
+            ref object? obj,
+            ref Type? objType,
+            string segment,
+            int depth,
+            Logs? logs,
+            BindingFlags flags,
+            ILogger? logger)
+        {
+            var padding = StringUtils.GetPadding(depth);
+
+            if (obj == null)
+            {
+                var msg = $"Cannot navigate segment '{segment}': object is null.";
+                logs?.Error(msg, depth);
+                if (logger?.IsEnabled(LogLevel.Error) == true)
+                    logger.LogError($"{padding}{msg}");
+                return false;
+            }
+
+            var resolvedType = obj.GetType();
+
+            if (TryParseBracketSegment(segment, out var innerKey))
+            {
+                // ── Array / IList ──────────────────────────────────────────────────────
+                if (obj is IList list)
+                {
+                    if (!int.TryParse(innerKey, out int idx))
+                    {
+                        var msg = $"Bracket segment '{segment}' cannot be used as index on type '{resolvedType.GetTypeShortName()}'. Expected integer index.";
+                        logs?.Error(msg, depth);
+                        if (logger?.IsEnabled(LogLevel.Error) == true)
+                            logger.LogError($"{padding}{msg}");
+                        return false;
+                    }
+
+                    if (idx < 0 || idx >= list.Count)
+                    {
+                        var msg = $"Bracket segment '{segment}' index out of range on type '{resolvedType.GetTypeShortName()}'. Array/list length is {list.Count}.";
+                        logs?.Error(msg, depth);
+                        if (logger?.IsEnabled(LogLevel.Error) == true)
+                            logger.LogError($"{padding}{msg}");
+                        return false;
+                    }
+
+                    obj     = list[idx];
+                    objType = TypeUtils.GetEnumerableItemType(resolvedType);
+                    return true;
+                }
+
+                // ── Dictionary ────────────────────────────────────────────────────────
+                if (TypeUtils.IsDictionary(resolvedType))
+                {
+                    var args    = TypeUtils.GetDictionaryGenericArguments(resolvedType);
+                    var keyType = args?[0] ?? typeof(object);
+                    var valType = args?[1] ?? typeof(object);
+
+                    object dictKey;
+                    try
+                    {
+                        dictKey = Convert.ChangeType(innerKey, keyType);
+                    }
+                    catch (Exception ex)
+                    {
+                        var msg = $"Bracket segment '{segment}' cannot be converted to key type '{keyType.GetTypeShortName()}' on type '{resolvedType.GetTypeShortName()}': {ex.Message}";
+                        logs?.Error(msg, depth);
+                        if (logger?.IsEnabled(LogLevel.Error) == true)
+                            logger.LogError($"{padding}{msg}");
+                        return false;
+                    }
+
+                    var dict = (IDictionary)obj;
+                    if (!dict.Contains(dictKey))
+                    {
+                        var msg = $"Bracket segment '{segment}' key not found in dictionary of type '{resolvedType.GetTypeShortName()}'.";
+                        logs?.Error(msg, depth);
+                        if (logger?.IsEnabled(LogLevel.Error) == true)
+                            logger.LogError($"{padding}{msg}");
+                        return false;
+                    }
+
+                    obj     = dict[dictKey];
+                    objType = valType;
+                    return true;
+                }
+
+                // ── Neither array/list nor dictionary ─────────────────────────────────
+                {
+                    var msg = $"Bracket segment '{segment}' cannot be used on type '{resolvedType.GetTypeShortName()}'. Type is not an array, list, or dictionary.";
+                    logs?.Error(msg, depth);
+                    if (logger?.IsEnabled(LogLevel.Error) == true)
+                        logger.LogError($"{padding}{msg}");
+                    return false;
+                }
+            }
+
+            // ── Plain segment — try field, then property ───────────────────────────────
+            var fieldInfo = TypeMemberUtils.GetField(resolvedType, flags, segment);
+            if (fieldInfo != null)
+            {
+                obj     = fieldInfo.GetValue(obj);
+                objType = fieldInfo.FieldType;
+                return true;
+            }
+
+            var propInfo = TypeMemberUtils.GetProperty(resolvedType, flags, segment);
+            if (propInfo != null)
+            {
+                obj     = propInfo.GetValue(obj);
+                objType = propInfo.PropertyType;
+                return true;
+            }
+
+            // ── Not found — detailed error with available members ──────────────────────
+            var fieldNames = resolvedType.GetFields(flags).Select(f => f.Name).ToList();
+            var propNames  = resolvedType.GetProperties(flags).Select(p => p.Name).ToList();
+            var fieldsStr  = fieldNames.Count > 0 ? string.Join(", ", fieldNames) : "none";
+            var propsStr   = propNames.Count  > 0 ? string.Join(", ", propNames)  : "none";
+
+            var errorMsg = $"Segment '{segment}' not found on type '{resolvedType.GetTypeShortName()}'."
+                         + $"\nAvailable fields: {fieldsStr}"
+                         + $"\nAvailable properties: {propsStr}";
+
+            logs?.Error(errorMsg, depth);
+            if (logger?.IsEnabled(LogLevel.Error) == true)
+                logger.LogError($"{padding}{errorMsg}");
+
+            return false;
+        }
+    }
+}

--- a/ReflectorNet/src/Reflector/Reflector.ReadAt.cs
+++ b/ReflectorNet/src/Reflector/Reflector.ReadAt.cs
@@ -177,10 +177,12 @@ namespace com.IvanMurzak.ReflectorNet
             }
 
             // ── Not found — detailed error with available members ──────────────────────
-            var fieldNames = resolvedType.GetFields(flags).Select(f => f.Name).ToList();
-            var propNames  = resolvedType.GetProperties(flags).Select(p => p.Name).ToList();
-            var fieldsStr  = fieldNames.Count > 0 ? string.Join(", ", fieldNames) : "none";
-            var propsStr   = propNames.Count  > 0 ? string.Join(", ", propNames)  : "none";
+            var serializableFields = GetSerializableFields(resolvedType, flags, logger);
+            var serializableProps  = GetSerializableProperties(resolvedType, flags, logger);
+            var fieldsStr = serializableFields != null ? string.Join(", ", serializableFields.Select(f => f.Name)) : "none";
+            var propsStr  = serializableProps  != null ? string.Join(", ", serializableProps .Select(p => p.Name)) : "none";
+            if (fieldsStr.Length == 0) fieldsStr = "none";
+            if (propsStr .Length == 0) propsStr  = "none";
 
             var errorMsg = $"Segment '{segment}' not found on type '{resolvedType.GetTypeShortName()}'."
                          + $"\nAvailable fields: {fieldsStr}"

--- a/ReflectorNet/src/Reflector/Reflector.View.cs
+++ b/ReflectorNet/src/Reflector/Reflector.View.cs
@@ -68,8 +68,9 @@ namespace com.IvanMurzak.ReflectorNet
 
                 if (!string.IsNullOrEmpty(query.NamePattern))
                 {
-                    var filtered = FilterByNamePattern(serialized, query.NamePattern);
-                    // If nothing matched, return root envelope with empty fields/props
+                    var rx = TryCompilePattern(query.NamePattern, logs, depth);
+                    var filtered = rx != null ? FilterByNamePattern(serialized, rx) : null;
+                    // If nothing matched (or invalid pattern), return root envelope with empty fields/props
                     serialized = filtered ?? new SerializedMember { name = serialized.name, typeName = serialized.typeName };
                 }
 
@@ -91,6 +92,7 @@ namespace com.IvanMurzak.ReflectorNet
         /// beginning with "orbit". maxDepth limits how many levels deep the search recurses
         /// (null = unlimited).
         ///
+        /// An invalid regex pattern logs an error and returns an empty list; nothing is thrown.
         /// Errors are accumulated in the optional Logs object; nothing is thrown.
         /// </summary>
         public IReadOnlyList<ViewMatch> Grep(
@@ -103,9 +105,12 @@ namespace com.IvanMurzak.ReflectorNet
             BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
             ILogger? logger = null)
         {
+            var rx = TryCompilePattern(namePattern, logs, depth);
+            if (rx == null) return new List<ViewMatch>().AsReadOnly();
+
             var matches = new List<ViewMatch>();
             var visited = new HashSet<object>(ObjectReferenceEqualityComparer.Instance);
-            GrepWalk(obj, obj?.GetType() ?? fallbackObjType, namePattern, maxDepth, 0,
+            GrepWalk(obj, rx, maxDepth, 0,
                      string.Empty, matches, visited, depth, logs, flags, logger);
             return matches.AsReadOnly();
         }
@@ -114,8 +119,7 @@ namespace com.IvanMurzak.ReflectorNet
 
         private void GrepWalk(
             object? obj,
-            Type? objType,
-            string namePattern,
+            Regex rx,
             int? maxDepth,
             int currentDepth,
             string currentPath,
@@ -129,8 +133,7 @@ namespace com.IvanMurzak.ReflectorNet
             if (obj == null) return;
             if (maxDepth.HasValue && currentDepth > maxDepth.Value) return;
 
-            var resolvedType = obj.GetType() ?? objType;
-            if (resolvedType == null) return;
+            var resolvedType = obj.GetType();
 
             // Circular-reference guard for reference types
             if (!resolvedType.IsValueType)
@@ -141,11 +144,10 @@ namespace com.IvanMurzak.ReflectorNet
             // Arrays / IList — recurse into elements (name-match does not apply to index paths)
             if (obj is IList list)
             {
-                var elementType = TypeUtils.GetEnumerableItemType(resolvedType);
                 for (int i = 0; i < list.Count; i++)
                 {
                     var elemPath = currentPath.Length == 0 ? $"[{i}]" : $"{currentPath}/[{i}]";
-                    GrepWalk(list[i], elementType, namePattern, maxDepth, currentDepth + 1,
+                    GrepWalk(list[i], rx, maxDepth, currentDepth + 1,
                              elemPath, matches, visited, serializeDepth, logs, flags, logger);
                 }
                 return; // arrays also implement IEnumerable — skip field/dict scanning
@@ -163,7 +165,7 @@ namespace com.IvanMurzak.ReflectorNet
                     try { fieldValue = field.GetValue(obj); }
                     catch { continue; }
 
-                    if (Regex.IsMatch(field.Name, namePattern, RegexOptions.IgnoreCase))
+                    if (rx.IsMatch(field.Name))
                     {
                         var serialized = Serialize(fieldValue, field.FieldType, name: field.Name,
                                                    depth: serializeDepth, logs: logs, flags: flags, logger: logger);
@@ -172,7 +174,7 @@ namespace com.IvanMurzak.ReflectorNet
 
                     // Recurse into non-primitive types (IList is handled by GrepWalk's own guard at entry)
                     if (!TypeUtils.IsPrimitive(field.FieldType))
-                        GrepWalk(fieldValue, field.FieldType, namePattern, maxDepth, currentDepth + 1,
+                        GrepWalk(fieldValue, rx, maxDepth, currentDepth + 1,
                                  fieldPath, matches, visited, serializeDepth, logs, flags, logger);
                 }
             }
@@ -191,7 +193,7 @@ namespace com.IvanMurzak.ReflectorNet
                     try { propValue = prop.GetValue(obj); }
                     catch { continue; }
 
-                    if (Regex.IsMatch(prop.Name, namePattern, RegexOptions.IgnoreCase))
+                    if (rx.IsMatch(prop.Name))
                     {
                         var serialized = Serialize(propValue, prop.PropertyType, name: prop.Name,
                                                    depth: serializeDepth, logs: logs, flags: flags, logger: logger);
@@ -200,7 +202,7 @@ namespace com.IvanMurzak.ReflectorNet
 
                     // Recurse into non-primitive types
                     if (!TypeUtils.IsPrimitive(prop.PropertyType))
-                        GrepWalk(propValue, prop.PropertyType, namePattern, maxDepth, currentDepth + 1,
+                        GrepWalk(propValue, rx, maxDepth, currentDepth + 1,
                                  propPath, matches, visited, serializeDepth, logs, flags, logger);
                 }
             }
@@ -208,13 +210,11 @@ namespace com.IvanMurzak.ReflectorNet
             // Dictionaries — recurse into values (name-match does not apply to key paths)
             if (TypeUtils.IsDictionary(resolvedType))
             {
-                var args    = TypeUtils.GetDictionaryGenericArguments(resolvedType);
-                var valType = args?[1] ?? typeof(object);
                 var dict    = (IDictionary)obj;
                 foreach (var key in dict.Keys)
                 {
                     var valuePath = currentPath.Length == 0 ? $"[{key}]" : $"{currentPath}/[{key}]";
-                    GrepWalk(dict[key], valType, namePattern, maxDepth, currentDepth + 1,
+                    GrepWalk(dict[key], rx, maxDepth, currentDepth + 1,
                              valuePath, matches, visited, serializeDepth, logs, flags, logger);
                 }
             }
@@ -253,14 +253,14 @@ namespace com.IvanMurzak.ReflectorNet
 
         /// <summary>
         /// Keeps only branches containing at least one field/property whose name matches
-        /// <paramref name="pattern"/> (regex, case-insensitive).
+        /// <paramref name="rx"/> (case-insensitive, pre-compiled).
         /// Returns null when nothing in this subtree matches.
         /// </summary>
-        private static SerializedMember? FilterByNamePattern(SerializedMember m, string pattern)
+        private static SerializedMember? FilterByNamePattern(SerializedMember m, Regex rx)
         {
-            var selfMatch      = m.name != null && Regex.IsMatch(m.name, pattern, RegexOptions.IgnoreCase);
-            var filteredFields = FilterListByNamePattern(m.fields, pattern);
-            var filteredProps  = FilterListByNamePattern(m.props,  pattern);
+            var selfMatch      = m.name != null && rx.IsMatch(m.name);
+            var filteredFields = FilterListByNamePattern(m.fields, rx);
+            var filteredProps  = FilterListByNamePattern(m.props,  rx);
 
             if (!selfMatch && filteredFields == null && filteredProps == null)
                 return null;
@@ -275,14 +275,14 @@ namespace com.IvanMurzak.ReflectorNet
             };
         }
 
-        private static SerializedMemberList? FilterListByNamePattern(SerializedMemberList? list, string pattern)
+        private static SerializedMemberList? FilterListByNamePattern(SerializedMemberList? list, Regex rx)
         {
             if (list == null || list.Count == 0) return null;
 
             SerializedMemberList? result = null;
             foreach (var m in list)
             {
-                var filtered = FilterByNamePattern(m, pattern);
+                var filtered = FilterByNamePattern(m, rx);
                 if (filtered != null)
                 {
                     result ??= new SerializedMemberList();
@@ -332,6 +332,25 @@ namespace com.IvanMurzak.ReflectorNet
                 }
             }
             return result;
+        }
+
+        // ─── Regex helper ─────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Compiles <paramref name="pattern"/> as a case-insensitive regex.
+        /// Returns null and logs an error if the pattern is invalid; nothing is thrown.
+        /// </summary>
+        private static Regex? TryCompilePattern(string pattern, Logs? logs, int depth = 0)
+        {
+            try
+            {
+                return new Regex(pattern, RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            }
+            catch (ArgumentException ex)
+            {
+                logs?.Error($"Invalid regex pattern '{pattern}': {ex.Message}", depth);
+                return null;
+            }
         }
 
         // Comparer that uses object identity (ReferenceEquals) rather than value equality.

--- a/ReflectorNet/src/Reflector/Reflector.View.cs
+++ b/ReflectorNet/src/Reflector/Reflector.View.cs
@@ -22,11 +22,14 @@ namespace com.IvanMurzak.ReflectorNet
         /// Serializes the object (or a navigated subtree) with optional filtering.
         /// Without a query (or with an empty query) this is equivalent to Serialize().
         ///
-        /// ViewQuery options:
+        /// ViewQuery options (applied in this order):
         ///   Path        — navigate to a path first, then serialize only that subtree
         ///   MaxDepth    — prune the returned tree to N levels (0 = root typeName/value only)
         ///   NamePattern — keep only branches containing a field/property name matching a .NET regex
         ///   TypeFilter  — keep only branches whose typeName resolves to a type assignable to this
+        ///
+        /// Filter order matters: MaxDepth prunes the tree before NamePattern/TypeFilter are applied,
+        /// so members deeper than MaxDepth are excluded even if their name or type would match.
         ///
         /// Errors are accumulated in the optional Logs object; nothing is thrown.
         /// </summary>
@@ -118,7 +121,7 @@ namespace com.IvanMurzak.ReflectorNet
             string currentPath,
             List<ViewMatch> matches,
             HashSet<object> visited,
-            int depth,
+            int serializeDepth,
             Logs? logs,
             BindingFlags flags,
             ILogger? logger)
@@ -143,7 +146,7 @@ namespace com.IvanMurzak.ReflectorNet
                 {
                     var elemPath = currentPath.Length == 0 ? $"[{i}]" : $"{currentPath}/[{i}]";
                     GrepWalk(list[i], elementType, namePattern, maxDepth, currentDepth + 1,
-                             elemPath, matches, visited, depth, logs, flags, logger);
+                             elemPath, matches, visited, serializeDepth, logs, flags, logger);
                 }
                 return; // arrays also implement IEnumerable — skip field/dict scanning
             }
@@ -163,14 +166,14 @@ namespace com.IvanMurzak.ReflectorNet
                     if (Regex.IsMatch(field.Name, namePattern, RegexOptions.IgnoreCase))
                     {
                         var serialized = Serialize(fieldValue, field.FieldType, name: field.Name,
-                                                   depth: depth, logs: logs, flags: flags, logger: logger);
+                                                   depth: serializeDepth, logs: logs, flags: flags, logger: logger);
                         matches.Add(new ViewMatch(fieldPath, serialized));
                     }
 
                     // Recurse into non-primitive types (IList is handled by GrepWalk's own guard at entry)
                     if (!TypeUtils.IsPrimitive(field.FieldType))
                         GrepWalk(fieldValue, field.FieldType, namePattern, maxDepth, currentDepth + 1,
-                                 fieldPath, matches, visited, depth, logs, flags, logger);
+                                 fieldPath, matches, visited, serializeDepth, logs, flags, logger);
                 }
             }
 
@@ -191,14 +194,14 @@ namespace com.IvanMurzak.ReflectorNet
                     if (Regex.IsMatch(prop.Name, namePattern, RegexOptions.IgnoreCase))
                     {
                         var serialized = Serialize(propValue, prop.PropertyType, name: prop.Name,
-                                                   depth: depth, logs: logs, flags: flags, logger: logger);
+                                                   depth: serializeDepth, logs: logs, flags: flags, logger: logger);
                         matches.Add(new ViewMatch(propPath, serialized));
                     }
 
                     // Recurse into non-primitive types
                     if (!TypeUtils.IsPrimitive(prop.PropertyType))
                         GrepWalk(propValue, prop.PropertyType, namePattern, maxDepth, currentDepth + 1,
-                                 propPath, matches, visited, depth, logs, flags, logger);
+                                 propPath, matches, visited, serializeDepth, logs, flags, logger);
                 }
             }
 
@@ -212,7 +215,7 @@ namespace com.IvanMurzak.ReflectorNet
                 {
                     var valuePath = currentPath.Length == 0 ? $"[{key}]" : $"{currentPath}/[{key}]";
                     GrepWalk(dict[key], valType, namePattern, maxDepth, currentDepth + 1,
-                             valuePath, matches, visited, depth, logs, flags, logger);
+                             valuePath, matches, visited, serializeDepth, logs, flags, logger);
                 }
             }
         }

--- a/ReflectorNet/src/Reflector/Reflector.View.cs
+++ b/ReflectorNet/src/Reflector/Reflector.View.cs
@@ -1,0 +1,339 @@
+/*
+ * ReflectorNet
+ * Author: Ivan Murzak (https://github.com/IvanMurzak)
+ * Copyright (c) 2025 Ivan Murzak
+ * Licensed under the Apache License, Version 2.0. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using com.IvanMurzak.ReflectorNet.Model;
+using com.IvanMurzak.ReflectorNet.Utils;
+using Microsoft.Extensions.Logging;
+
+namespace com.IvanMurzak.ReflectorNet
+{
+    public partial class Reflector
+    {
+        /// <summary>
+        /// Serializes the object (or a navigated subtree) with optional filtering.
+        /// Without a query (or with an empty query) this is equivalent to Serialize().
+        ///
+        /// ViewQuery options:
+        ///   Path        — navigate to a path first, then serialize only that subtree
+        ///   MaxDepth    — prune the returned tree to N levels (0 = root typeName/value only)
+        ///   NamePattern — keep only branches containing a field/property name matching a .NET regex
+        ///   TypeFilter  — keep only branches whose typeName resolves to a type assignable to this
+        ///
+        /// Errors are accumulated in the optional Logs object; nothing is thrown.
+        /// </summary>
+        public SerializedMember? View(
+            object? obj,
+            ViewQuery? query = null,
+            Type? fallbackObjType = null,
+            int depth = 0,
+            Logs? logs = null,
+            BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+            ILogger? logger = null)
+        {
+            // Step 1: Navigate to path if specified
+            var target     = obj;
+            var targetType = obj?.GetType() ?? fallbackObjType;
+
+            if (!string.IsNullOrEmpty(query?.Path))
+            {
+                var segments = ParsePath(query!.Path);
+                for (int i = 0; i < segments.Length; i++)
+                {
+                    if (!TryNavigateOneSegment(ref target, ref targetType, segments[i], depth + i, logs, flags, logger))
+                        return null;
+                }
+                depth += segments.Length;
+            }
+
+            // Step 2: Serialize
+            var serialized = Serialize(target, targetType ?? fallbackObjType, depth: depth, logs: logs, flags: flags, logger: logger);
+
+            // Step 3: Apply filters
+            if (query != null)
+            {
+                if (query.MaxDepth.HasValue)
+                    serialized = PruneToDepth(serialized, query.MaxDepth.Value);
+
+                if (!string.IsNullOrEmpty(query.NamePattern))
+                {
+                    var filtered = FilterByNamePattern(serialized, query.NamePattern);
+                    // If nothing matched, return root envelope with empty fields/props
+                    serialized = filtered ?? new SerializedMember { name = serialized.name, typeName = serialized.typeName };
+                }
+
+                if (query.TypeFilter != null)
+                {
+                    var filtered = FilterByType(serialized, query.TypeFilter);
+                    serialized = filtered ?? new SerializedMember { name = serialized.name, typeName = serialized.typeName };
+                }
+            }
+
+            return serialized;
+        }
+
+        /// <summary>
+        /// Searches the object graph for all fields and properties whose name matches the given
+        /// .NET regex pattern (case-insensitive) and returns them as a flat list of path+value pairs.
+        ///
+        /// Similar to the grep command: a plain string matches exactly, "orbit.*" matches all names
+        /// beginning with "orbit". maxDepth limits how many levels deep the search recurses
+        /// (null = unlimited).
+        ///
+        /// Errors are accumulated in the optional Logs object; nothing is thrown.
+        /// </summary>
+        public IReadOnlyList<ViewMatch> Grep(
+            object? obj,
+            string namePattern,
+            int? maxDepth = null,
+            Type? fallbackObjType = null,
+            int depth = 0,
+            Logs? logs = null,
+            BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+            ILogger? logger = null)
+        {
+            var matches = new List<ViewMatch>();
+            var visited = new HashSet<int>();
+            GrepWalk(obj, obj?.GetType() ?? fallbackObjType, namePattern, maxDepth, 0,
+                     string.Empty, matches, visited, depth, logs, flags, logger);
+            return matches.AsReadOnly();
+        }
+
+        // ─── Grep walker ──────────────────────────────────────────────────────────────
+
+        private void GrepWalk(
+            object? obj,
+            Type? objType,
+            string namePattern,
+            int? maxDepth,
+            int currentDepth,
+            string currentPath,
+            List<ViewMatch> matches,
+            HashSet<int> visited,
+            int depth,
+            Logs? logs,
+            BindingFlags flags,
+            ILogger? logger)
+        {
+            if (obj == null) return;
+            if (maxDepth.HasValue && currentDepth > maxDepth.Value) return;
+
+            var resolvedType = obj.GetType() ?? objType;
+            if (resolvedType == null) return;
+
+            // Circular-reference guard for reference types
+            if (!resolvedType.IsValueType)
+            {
+                var id = RuntimeHelpers.GetHashCode(obj);
+                if (!visited.Add(id)) return;
+            }
+
+            // Arrays / IList — recurse into elements (name-match does not apply to index paths)
+            if (obj is IList list)
+            {
+                var elementType = TypeUtils.GetEnumerableItemType(resolvedType);
+                for (int i = 0; i < list.Count; i++)
+                {
+                    var elemPath = currentPath.Length == 0 ? $"[{i}]" : $"{currentPath}/[{i}]";
+                    GrepWalk(list[i], elementType, namePattern, maxDepth, currentDepth + 1,
+                             elemPath, matches, visited, depth, logs, flags, logger);
+                }
+                return; // arrays also implement IEnumerable — skip field/dict scanning
+            }
+
+            // Fields
+            var fields = GetSerializableFields(resolvedType, flags, logger);
+            if (fields != null)
+            {
+                foreach (var field in fields)
+                {
+                    var fieldPath = currentPath.Length == 0 ? field.Name : $"{currentPath}/{field.Name}";
+
+                    object? fieldValue;
+                    try { fieldValue = field.GetValue(obj); }
+                    catch { continue; }
+
+                    if (Regex.IsMatch(field.Name, namePattern, RegexOptions.IgnoreCase))
+                    {
+                        var serialized = Serialize(fieldValue, field.FieldType, name: field.Name,
+                                                   depth: depth, logs: logs, flags: flags, logger: logger);
+                        matches.Add(new ViewMatch(fieldPath, serialized));
+                    }
+
+                    // Recurse into non-primitive, non-list types
+                    if (!TypeUtils.IsPrimitive(field.FieldType) && !(fieldValue is IList))
+                        GrepWalk(fieldValue, field.FieldType, namePattern, maxDepth, currentDepth + 1,
+                                 fieldPath, matches, visited, depth, logs, flags, logger);
+                    else if (fieldValue is IList)
+                        GrepWalk(fieldValue, field.FieldType, namePattern, maxDepth, currentDepth + 1,
+                                 fieldPath, matches, visited, depth, logs, flags, logger);
+                }
+            }
+
+            // Properties
+            var props = GetSerializableProperties(resolvedType, flags, logger);
+            if (props != null)
+            {
+                foreach (var prop in props)
+                {
+                    if (!prop.CanRead) continue;
+
+                    var propPath = currentPath.Length == 0 ? prop.Name : $"{currentPath}/{prop.Name}";
+
+                    object? propValue;
+                    try { propValue = prop.GetValue(obj); }
+                    catch { continue; }
+
+                    if (Regex.IsMatch(prop.Name, namePattern, RegexOptions.IgnoreCase))
+                    {
+                        var serialized = Serialize(propValue, prop.PropertyType, name: prop.Name,
+                                                   depth: depth, logs: logs, flags: flags, logger: logger);
+                        matches.Add(new ViewMatch(propPath, serialized));
+                    }
+
+                    // Recurse into non-primitive types
+                    if (!TypeUtils.IsPrimitive(prop.PropertyType))
+                        GrepWalk(propValue, prop.PropertyType, namePattern, maxDepth, currentDepth + 1,
+                                 propPath, matches, visited, depth, logs, flags, logger);
+                }
+            }
+
+            // Dictionaries — recurse into values (name-match does not apply to key paths)
+            if (TypeUtils.IsDictionary(resolvedType))
+            {
+                var args    = TypeUtils.GetDictionaryGenericArguments(resolvedType);
+                var valType = args?[1] ?? typeof(object);
+                var dict    = (IDictionary)obj;
+                foreach (var key in dict.Keys)
+                {
+                    var valuePath = currentPath.Length == 0 ? $"[{key}]" : $"{currentPath}/[{key}]";
+                    GrepWalk(dict[key], valType, namePattern, maxDepth, currentDepth + 1,
+                             valuePath, matches, visited, depth, logs, flags, logger);
+                }
+            }
+        }
+
+        // ─── Filter helpers ───────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Returns a shallow copy of <paramref name="m"/> with all fields/props beyond
+        /// <paramref name="maxRelativeDepth"/> levels stripped.
+        /// maxRelativeDepth = 0 keeps the node itself (typeName + value) but removes all children.
+        /// </summary>
+        private static SerializedMember PruneToDepth(SerializedMember m, int maxRelativeDepth)
+        {
+            if (maxRelativeDepth <= 0)
+                return new SerializedMember { name = m.name, typeName = m.typeName, valueJsonElement = m.valueJsonElement };
+
+            var result = new SerializedMember { name = m.name, typeName = m.typeName, valueJsonElement = m.valueJsonElement };
+
+            if (m.fields != null)
+            {
+                result.fields = new SerializedMemberList(m.fields.Count);
+                foreach (var f in m.fields)
+                    result.fields.Add(PruneToDepth(f, maxRelativeDepth - 1));
+            }
+
+            if (m.props != null)
+            {
+                result.props = new SerializedMemberList(m.props.Count);
+                foreach (var p in m.props)
+                    result.props.Add(PruneToDepth(p, maxRelativeDepth - 1));
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Keeps only branches containing at least one field/property whose name matches
+        /// <paramref name="pattern"/> (regex, case-insensitive).
+        /// Returns null when nothing in this subtree matches.
+        /// </summary>
+        private static SerializedMember? FilterByNamePattern(SerializedMember m, string pattern)
+        {
+            var selfMatch      = m.name != null && Regex.IsMatch(m.name, pattern, RegexOptions.IgnoreCase);
+            var filteredFields = FilterListByNamePattern(m.fields, pattern);
+            var filteredProps  = FilterListByNamePattern(m.props,  pattern);
+
+            if (!selfMatch && filteredFields == null && filteredProps == null)
+                return null;
+
+            return new SerializedMember
+            {
+                name             = m.name,
+                typeName         = m.typeName,
+                valueJsonElement = m.valueJsonElement,
+                fields           = selfMatch ? m.fields : filteredFields,
+                props            = selfMatch ? m.props  : filteredProps,
+            };
+        }
+
+        private static SerializedMemberList? FilterListByNamePattern(SerializedMemberList? list, string pattern)
+        {
+            if (list == null || list.Count == 0) return null;
+
+            SerializedMemberList? result = null;
+            foreach (var m in list)
+            {
+                var filtered = FilterByNamePattern(m, pattern);
+                if (filtered != null)
+                {
+                    result ??= new SerializedMemberList();
+                    result.Add(filtered);
+                }
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Keeps only branches where the resolved typeName is assignable to <paramref name="typeFilter"/>.
+        /// Returns null when nothing in this subtree matches.
+        /// </summary>
+        private static SerializedMember? FilterByType(SerializedMember m, Type typeFilter)
+        {
+            var memberType = TypeUtils.GetType(m.typeName);
+            var typeMatch  = memberType != null && typeFilter.IsAssignableFrom(memberType);
+
+            var filteredFields = FilterListByType(m.fields, typeFilter);
+            var filteredProps  = FilterListByType(m.props,  typeFilter);
+
+            if (!typeMatch && filteredFields == null && filteredProps == null)
+                return null;
+
+            return new SerializedMember
+            {
+                name             = m.name,
+                typeName         = m.typeName,
+                valueJsonElement = m.valueJsonElement,
+                fields           = typeMatch ? m.fields : filteredFields,
+                props            = typeMatch ? m.props  : filteredProps,
+            };
+        }
+
+        private static SerializedMemberList? FilterListByType(SerializedMemberList? list, Type typeFilter)
+        {
+            if (list == null || list.Count == 0) return null;
+
+            SerializedMemberList? result = null;
+            foreach (var m in list)
+            {
+                var filtered = FilterByType(m, typeFilter);
+                if (filtered != null)
+                {
+                    result ??= new SerializedMemberList();
+                    result.Add(filtered);
+                }
+            }
+            return result;
+        }
+    }
+}

--- a/ReflectorNet/src/Reflector/Reflector.View.cs
+++ b/ReflectorNet/src/Reflector/Reflector.View.cs
@@ -9,7 +9,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using com.IvanMurzak.ReflectorNet.Model;
 using com.IvanMurzak.ReflectorNet.Utils;
@@ -102,7 +101,7 @@ namespace com.IvanMurzak.ReflectorNet
             ILogger? logger = null)
         {
             var matches = new List<ViewMatch>();
-            var visited = new HashSet<int>();
+            var visited = new HashSet<object>(ObjectReferenceEqualityComparer.Instance);
             GrepWalk(obj, obj?.GetType() ?? fallbackObjType, namePattern, maxDepth, 0,
                      string.Empty, matches, visited, depth, logs, flags, logger);
             return matches.AsReadOnly();
@@ -118,7 +117,7 @@ namespace com.IvanMurzak.ReflectorNet
             int currentDepth,
             string currentPath,
             List<ViewMatch> matches,
-            HashSet<int> visited,
+            HashSet<object> visited,
             int depth,
             Logs? logs,
             BindingFlags flags,
@@ -133,8 +132,7 @@ namespace com.IvanMurzak.ReflectorNet
             // Circular-reference guard for reference types
             if (!resolvedType.IsValueType)
             {
-                var id = RuntimeHelpers.GetHashCode(obj);
-                if (!visited.Add(id)) return;
+                if (!visited.Add(obj)) return;
             }
 
             // Arrays / IList — recurse into elements (name-match does not apply to index paths)
@@ -169,11 +167,8 @@ namespace com.IvanMurzak.ReflectorNet
                         matches.Add(new ViewMatch(fieldPath, serialized));
                     }
 
-                    // Recurse into non-primitive, non-list types
-                    if (!TypeUtils.IsPrimitive(field.FieldType) && !(fieldValue is IList))
-                        GrepWalk(fieldValue, field.FieldType, namePattern, maxDepth, currentDepth + 1,
-                                 fieldPath, matches, visited, depth, logs, flags, logger);
-                    else if (fieldValue is IList)
+                    // Recurse into non-primitive types (IList is handled by GrepWalk's own guard at entry)
+                    if (!TypeUtils.IsPrimitive(field.FieldType))
                         GrepWalk(fieldValue, field.FieldType, namePattern, maxDepth, currentDepth + 1,
                                  fieldPath, matches, visited, depth, logs, flags, logger);
                 }
@@ -334,6 +329,18 @@ namespace com.IvanMurzak.ReflectorNet
                 }
             }
             return result;
+        }
+
+        // Comparer that uses object identity (ReferenceEquals) rather than value equality.
+        // Avoids false-positive cycle-detection when two distinct objects share the same GetHashCode().
+        // netstandard2.1 does not provide System.Collections.Generic.ReferenceEqualityComparer,
+        // so we supply our own.
+        private sealed class ObjectReferenceEqualityComparer : IEqualityComparer<object>
+        {
+            public static readonly ObjectReferenceEqualityComparer Instance = new ObjectReferenceEqualityComparer();
+            private ObjectReferenceEqualityComparer() { }
+            public new bool Equals(object? x, object? y) => ReferenceEquals(x, y);
+            public int GetHashCode(object obj) => System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(obj);
         }
     }
 }


### PR DESCRIPTION
This pull request introduces new advanced object inspection and filtering capabilities to the ReflectorNet library. It adds a flexible `View` API for selective serialization of object graphs, a `Grep` method for searching object trees by field/property name patterns, and supporting model classes and helpers. These changes make it much easier to query and introspect complex objects with filtering by path, name, type, and depth.

The most important changes include:

**New View and Grep APIs:**

* Added the `View` method to the `Reflector` class, allowing serialization of an object or a subtree with filtering options such as path navigation, maximum depth, name regex pattern, and type filtering. This enables precise control over what parts of an object are returned.
* Added the `Grep` method to the `Reflector` class, which recursively searches an object graph for all fields and properties whose names match a provided regex pattern, returning a flat list of matches with their paths and values.

**Supporting Models and Data Structures:**

* Introduced the `ViewQuery` class to encapsulate options for the `View` method (path, name pattern, max depth, type filter), and the `ViewMatch` class to represent individual search results from `Grep`.

**Path Navigation Enhancements:**

* Implemented the `TryReadAt` method and the shared `TryNavigateOneSegment` helper in `Reflector`, enabling robust navigation to fields, array/list elements, or dictionary entries by string path, with detailed error reporting and support for bracket notation.

**Filtering and Pruning Helpers:**

* Added internal helpers to prune serialized trees to a maximum depth and to filter by name pattern or type, ensuring only relevant branches are included in the result.

These enhancements significantly improve the flexibility and usability of object inspection and serialization in ReflectorNet.