### PR TITLE
Add atomic modification API and JSON patch support with enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Traditional reflection is brittle and requires exact matches. ReflectorNet is bu
 *   **🔍 Fuzzy Matching**: Discover methods and types even with incomplete names or parameters (configurable match levels 0-6).
 *   **📦 Type-Safe Serialization**: Preserves full type information, supporting complex nested objects, collections, and custom types.
 *   **🔄 In-Place Modification**: Update existing object instances from serialized data without breaking references.
+*   **🎯 Atomic Path-Based Modification**: Navigate directly to any field, array element, or dictionary entry by path and modify only that — without touching anything else.
+*   **🩹 JSON Patch**: Apply a JSON document to modify multiple fields at different depths in a single call, following JSON Merge Patch (RFC 7396) semantics.
 *   **📄 JSON Schema Generation**: Automatically generate schemas for your types and methods to feed into LLM context windows.
 
 ## 📦 Installation
@@ -79,7 +81,113 @@ var existingInstance = new MyComplexClass();
 bool success = reflector.TryModify(ref existingInstance, serialized);
 ```
 
-### 5. Dynamic Method Invocation
+### 5. Atomic Path-Based Modification
+
+Navigate directly to a specific field, array element, or dictionary entry by path and modify **only that target** — no surrounding data is affected.
+
+**Path format:**
+
+| Segment | Meaning |
+| --- | --- |
+| `fieldName` | Field or property by name |
+| `[i]` | Array / list element at index `i` |
+| `[key]` | Dictionary entry with key `key` (any key type) |
+
+A leading `#/` is stripped automatically for compatibility with `SerializationContext` paths.
+
+```csharp
+var reflector = new Reflector();
+object? system = new SolarSystem
+{
+    globalOrbitSpeedMultiplier = 1f,
+    celestialBodies = new[]
+    {
+        new CelestialBody { orbitRadius = 10f, orbitSpeed = 1f },
+        new CelestialBody { orbitRadius = 20f, orbitSpeed = 2f },
+    }
+};
+
+// Modify a root field
+reflector.TryModifyAt<float>(ref system, "globalOrbitSpeedMultiplier", 5f);
+
+// Modify a nested field — only that one field changes
+reflector.TryModifyAt<float>(ref system, "celestialBodies/[0]/orbitRadius", 999f);
+
+// Dictionary entry — string or integer keys both work
+object? container = new Config { settings = new Dictionary<string, int> { ["timeout"] = 10 } };
+reflector.TryModifyAt<int>(ref container, "settings/[timeout]", 60);
+```
+
+For partial updates of a complex object at a path, supply a `SerializedMember` that lists only the fields to change:
+
+```csharp
+var patch = new SerializedMember { typeName = typeof(CelestialBody).GetTypeId() };
+patch.SetFieldValue(reflector, "orbitRadius", 777f); // only orbitRadius changes
+
+var logs = new Logs();
+reflector.TryModifyAt(ref system, "celestialBodies/[1]", patch, logs: logs);
+// celestialBodies[1].orbitSpeed is untouched
+```
+
+Errors are collected in the `Logs` object — nothing is thrown:
+
+```csharp
+var logs = new Logs();
+bool ok = reflector.TryModifyAt<float>(ref system, "doesNotExist", 5f, logs: logs);
+// ok == false; logs contains:
+// "Segment 'doesNotExist' not found on type 'SolarSystem'.
+//  Available fields: globalOrbitSpeedMultiplier, celestialBodies, ..."
+```
+
+### 6. JSON Patch
+
+Apply a JSON document to modify multiple fields at different depths in a single call.
+Follows **JSON Merge Patch** (RFC 7396) semantics, extended with bracket-notation keys for arrays and dictionaries.
+
+```csharp
+var reflector = new Reflector();
+object? system = new SolarSystem { /* ... */ };
+
+// Modify several fields at once — untouched fields are preserved
+var logs = new Logs();
+bool ok = reflector.TryPatch(ref system, """
+{
+  "globalOrbitSpeedMultiplier": 5.0,
+  "globalSizeMultiplier": 2.0,
+  "celestialBodies": {
+    "[0]": { "orbitRadius": 42.0 }
+  }
+}
+""", logs: logs);
+```
+
+**Patch document rules:**
+
+* A JSON **object** key navigates into that field (`"fieldName"`) or element (`"[i]"` / `"[key]"`)
+* A JSON **non-object** value sets the field directly
+* `null` sets the field to `null`
+* `"$type"` key inside a JSON object specifies a desired subtype — the existing instance is replaced with a fresh instance of the new type before applying the remaining keys
+
+```csharp
+// Replace a base-type field with a derived type and set its fields
+reflector.TryPatch(ref system, """
+{
+  "star": {
+    "$type": "MyNamespace.NeutronStar",
+    "mass": 2.5
+  }
+}
+""");
+```
+
+A `JsonElement` overload is also available when you already have a parsed document:
+
+```csharp
+using var doc = JsonDocument.Parse(@"{ ""globalOrbitSpeedMultiplier"": 9.0 }");
+reflector.TryPatch(ref system, doc.RootElement, logs: logs);
+```
+
+### 7. Dynamic Method Invocation
 
 Allow AI to find and call methods without knowing the exact signature.
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Traditional reflection is brittle and requires exact matches. ReflectorNet is bu
 *   **🔄 In-Place Modification**: Update existing object instances from serialized data without breaking references.
 *   **🎯 Atomic Path-Based Modification**: Navigate directly to any field, array element, or dictionary entry by path and modify only that — without touching anything else.
 *   **🩹 JSON Patch**: Apply a JSON document to modify multiple fields at different depths in a single call, following JSON Merge Patch (RFC 7396) semantics.
+*   **🔎 View & Grep**: Read exactly what you need — navigate to a subtree, filter by name pattern or type, or grep the entire live object graph for all fields matching a regex. The read-side counterpart to path-based modification.
 *   **📄 JSON Schema Generation**: Automatically generate schemas for your types and methods to feed into LLM context windows.
 
 ## 📦 Installation
@@ -187,7 +188,134 @@ using var doc = JsonDocument.Parse(@"{ ""globalOrbitSpeedMultiplier"": 9.0 }");
 reflector.TryPatch(ref system, doc.RootElement, logs: logs);
 ```
 
-### 7. Dynamic Method Invocation
+### 7. View & Grep — Read-Side Navigation
+
+Read exactly the data you need from a live object — navigate to a specific subtree, filter by name or type, or grep the entire graph for every field matching a pattern.
+This is the read-side counterpart to [Atomic Path-Based Modification](#5-atomic-path-based-modification).
+
+---
+
+#### `reflector.View` — filtered serialization
+
+Returns a `SerializedMember` tree with optional path navigation and post-filters applied.
+
+```csharp
+var reflector = new Reflector();
+object? system = new SolarSystem
+{
+    globalOrbitSpeedMultiplier = 1f,
+    globalSizeMultiplier       = 2f,
+    celestialBodies = new[]
+    {
+        new CelestialBody { orbitRadius = 10f, orbitSpeed = 1f },
+        new CelestialBody { orbitRadius = 20f, orbitSpeed = 2f },
+    }
+};
+
+// Full view — equivalent to Serialize()
+SerializedMember? full = reflector.View(system);
+
+// Navigate to a subtree (same path format as TryModifyAt)
+SerializedMember? firstBody = reflector.View(system,
+    new ViewQuery { Path = "celestialBodies/[0]" });
+// firstBody.typeName contains "CelestialBody"
+
+// Depth-limited — MaxDepth=0 returns root node only (no children)
+SerializedMember? shallow = reflector.View(system,
+    new ViewQuery { MaxDepth = 1 });
+
+// Pattern filter — keep only branches containing a matching field name
+// Accepts any .NET regex; matching is case-insensitive
+SerializedMember? orbitFields = reflector.View(system,
+    new ViewQuery { NamePattern = "^orbit" });
+
+// Type filter — keep only branches whose resolved type is assignable to float
+SerializedMember? floatFields = reflector.View(system,
+    new ViewQuery { TypeFilter = typeof(float) });
+
+// Combined — navigate first, then filter
+SerializedMember? result = reflector.View(system, new ViewQuery
+{
+    Path        = "celestialBodies/[0]",
+    NamePattern = "^orbit",
+    MaxDepth    = 2,
+});
+```
+
+When a filter produces no matches the **root envelope is still returned** with an empty fields collection so that `result.typeName` always identifies the navigated node's type.
+
+**`ViewQuery` options:**
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `Path` | `string?` | `null` | Navigate to this path before serializing (same format as `TryModifyAt`) |
+| `MaxDepth` | `int?` | `null` | Maximum depth of returned tree (`0` = root node only, no children) |
+| `NamePattern` | `string?` | `null` | .NET regex matched against field / property names (case-insensitive) |
+| `TypeFilter` | `Type?` | `null` | Keep only branches whose resolved runtime type is assignable to this type |
+
+---
+
+#### `reflector.TryReadAt` — single-value path read
+
+Navigate to exactly one value by path and serialize it. Mirrors `TryModifyAt` but reads instead of writes.
+
+```csharp
+// Scalar leaf
+bool ok = reflector.TryReadAt(system, "celestialBodies/[0]/orbitRadius", out SerializedMember? r);
+if (ok)
+    Console.WriteLine(r!.GetValue<float>(reflector)); // 10f
+
+// Composite node — result has full fields tree for the navigated object
+reflector.TryReadAt(system, "celestialBodies/[0]", out var body);
+float radius = body!.fields!.First(f => f.name == "orbitRadius").GetValue<float>(reflector);
+
+// Dictionary access — string or any key type
+reflector.TryReadAt(container, "config/[timeout]", out var timeout);
+int ms = timeout!.GetValue<int>(reflector); // 30
+
+// Invalid paths return false; errors are collected in Logs — nothing is thrown
+var logs = new Logs();
+bool ok2 = reflector.TryReadAt(system, "doesNotExist", out _, logs: logs);
+// ok2 == false
+// logs: "Segment 'doesNotExist' not found on type 'SolarSystem'.
+//        Available fields: globalOrbitSpeedMultiplier, celestialBodies, ..."
+```
+
+---
+
+#### `reflector.Grep` — grep the live object graph
+
+Walks the entire live object graph and returns a flat list of every field / property whose name matches the given regex pattern — like the `grep` command, but for in-RAM objects.
+
+```csharp
+// Find every field whose name starts with "orbit"
+IReadOnlyList<ViewMatch> hits = reflector.Grep(system, "^orbit");
+
+foreach (var hit in hits)
+    Console.WriteLine($"{hit.Path} = {hit.Value.GetValue<float>(reflector)}");
+// celestialBodies/[0]/orbitRadius = 10
+// celestialBodies/[0]/orbitSpeed  = 1
+// celestialBodies/[1]/orbitRadius = 20
+// celestialBodies/[1]/orbitSpeed  = 2
+
+// Limit search depth (0 = top-level fields only, no recursion)
+IReadOnlyList<ViewMatch> topLevel = reflector.Grep(system, ".*", maxDepth: 0);
+
+// Exact name — anchored regex
+IReadOnlyList<ViewMatch> exact = reflector.Grep(system, "^globalOrbitSpeedMultiplier$");
+Console.WriteLine(exact[0].Path);  // "globalOrbitSpeedMultiplier"
+```
+
+Each `ViewMatch` exposes:
+
+* `Path` — full slash-delimited path, e.g. `"celestialBodies/[0]/orbitRadius"`
+* `Value` — `SerializedMember` of the matched field, ready for `GetValue<T>(reflector)`
+
+> **Grep vs. View + NamePattern**: `Grep` walks the **live object graph** and can find fields inside array elements. `View` + `NamePattern` filters the `SerializedMember` tree after serialization; array element contents are stored as JSON and are not individually filterable by name. Use `Grep` when you need to search inside arrays.
+
+---
+
+### 8. Dynamic Method Invocation
 
 Allow AI to find and call methods without knowing the exact signature.
 
@@ -218,7 +346,7 @@ string result = reflector.MethodCall(
 Console.WriteLine(result); // Output: [Success] 30
 ```
 
-### 6. Method Inspection & Schema Generation
+### 9. Method Inspection & Schema Generation
 
 Generate JSON schemas for types and methods to help LLMs understand your code structure.
 

--- a/ReflectorNet.Tests/src/ReflectorTests/AtomicModifyTests.cs
+++ b/ReflectorNet.Tests/src/ReflectorTests/AtomicModifyTests.cs
@@ -362,6 +362,177 @@ namespace com.IvanMurzak.ReflectorNet.Tests.ReflectorTests
             Assert.Equal(9f, ((SolarSystem)obj!).globalOrbitSpeedMultiplier);
         }
 
+        // ─── TryPatch — null value sets field to null (RFC 7396) ──────────────────
+
+        [Fact]
+        public void TryPatch_NullValue_SetsFieldToNull()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem { sun = new GameObjectRef { instanceID = 1 } };
+            object? obj = system;
+
+            var logs = new Logs();
+            var success = reflector.TryPatch(ref obj, @"{""sun"": null}", logs: logs);
+
+            _output.WriteLine(logs.ToString());
+            Assert.True(success);
+            Assert.Null(((SolarSystem)obj!).sun);
+        }
+
+        // ─── TryPatch — $type polymorphic replacement ─────────────────────────────
+
+        [Fact]
+        public void TryPatch_TypeHint_PolymorphicReplacement()
+        {
+            var reflector = new Reflector();
+            var container = new AnimalContainer { animal = new Animal { name = "Cat" } };
+            object? obj = container;
+
+            var dogTypeId = typeof(Dog).GetTypeId();
+            var json = $@"{{""animal"": {{""$type"": ""{dogTypeId}"", ""name"": ""Rex"", ""breed"": ""Husky""}}}}";
+
+            var logs = new Logs();
+            var success = reflector.TryPatch(ref obj, json, logs: logs);
+
+            _output.WriteLine(logs.ToString());
+            Assert.True(success);
+            var result = (AnimalContainer)obj!;
+            Assert.IsType<Dog>(result.animal);
+            Assert.Equal("Rex", result.animal!.name);
+            Assert.Equal("Husky", ((Dog)result.animal).breed);
+        }
+
+        // ─── TryPatch — $type incompatible type logs error ────────────────────────
+
+        [Fact]
+        public void TryPatch_TypeHint_IncompatibleType_LogsError()
+        {
+            var reflector = new Reflector();
+            var container = new AnimalContainer { animal = new Animal { name = "Cat" } };
+            object? obj = container;
+
+            var incompatibleTypeId = typeof(SolarSystem).GetTypeId();
+            var json = $@"{{""animal"": {{""$type"": ""{incompatibleTypeId}""}}}}";
+
+            var logs = new Logs();
+            var success = reflector.TryPatch(ref obj, json, logs: logs);
+
+            var logsText = logs.ToString();
+            _output.WriteLine(logsText);
+            Assert.False(success);
+            Assert.Contains("not assignable", logsText);
+            Assert.IsType<Animal>(((AnimalContainer)obj!).animal); // field untouched
+        }
+
+        // ─── TryPatch — $type unknown type string logs error ──────────────────────
+
+        [Fact]
+        public void TryPatch_TypeHint_UnknownType_LogsError()
+        {
+            var reflector = new Reflector();
+            var container = new AnimalContainer { animal = new Animal { name = "Cat" } };
+            object? obj = container;
+
+            var json = @"{""animal"": {""$type"": ""NoSuchType.Anywhere""}}";
+
+            var logs = new Logs();
+            var success = reflector.TryPatch(ref obj, json, logs: logs);
+
+            var logsText = logs.ToString();
+            _output.WriteLine(logsText);
+            Assert.False(success);
+            Assert.Contains("could not be resolved", logsText);
+        }
+
+        // ─── TryPatch — unknown key returns false and logs error ──────────────────
+
+        [Fact]
+        public void TryPatch_UnknownKey_ReturnsFalseAndLogsError()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem { globalOrbitSpeedMultiplier = 1f };
+            object? obj = system;
+            var logs = new Logs();
+
+            var success = reflector.TryPatch(ref obj, @"{""doesNotExist"": 99.0}", logs: logs);
+
+            var logsText = logs.ToString();
+            _output.WriteLine(logsText);
+            Assert.False(success);
+            Assert.Contains("doesNotExist", logsText);
+            Assert.Equal(1f, ((SolarSystem)obj!).globalOrbitSpeedMultiplier); // unchanged
+        }
+
+        // ─── TryModifyAt — List<T> element (IList branch) ────────────────────────
+
+        [Fact]
+        public void TryModifyAt_ListElement()
+        {
+            var reflector = new Reflector();
+            var container = new ListContainer
+            {
+                bodies = new List<SolarSystem.CelestialBody>
+                {
+                    new SolarSystem.CelestialBody { orbitRadius = 10f, orbitSpeed = 1f },
+                    new SolarSystem.CelestialBody { orbitRadius = 20f, orbitSpeed = 2f },
+                }
+            };
+            object? obj = container;
+
+            var success = reflector.TryModifyAt<float>(ref obj, "bodies/[0]/orbitRadius", 55f);
+
+            Assert.True(success);
+            var result = (ListContainer)obj!;
+            Assert.Equal(55f, result.bodies[0].orbitRadius);
+            Assert.Equal(1f,  result.bodies[0].orbitSpeed);  // untouched
+            Assert.Equal(20f, result.bodies[1].orbitRadius); // untouched
+        }
+
+        // ─── TryModifyAt — three-level path (field/index/property) ───────────────
+
+        [Fact]
+        public void TryModifyAt_ThreeLevelPath()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem
+            {
+                celestialBodies = new[]
+                {
+                    new SolarSystem.CelestialBody { orbitTilt = new Vector3(1f, 2f, 3f) },
+                }
+            };
+            object? obj = system;
+
+            var success = reflector.TryModifyAt<float>(ref obj, "celestialBodies/[0]/orbitTilt/x", 99f);
+
+            Assert.True(success);
+            var result = (SolarSystem)obj!;
+            Assert.Equal(99f, result.celestialBodies![0].orbitTilt.x);
+            Assert.Equal(2f,  result.celestialBodies![0].orbitTilt.y); // untouched
+            Assert.Equal(3f,  result.celestialBodies![0].orbitTilt.z); // untouched
+        }
+
+        // ─── TryModifyAt — empty path delegates to TryModify on root ─────────────
+
+        [Fact]
+        public void TryModifyAt_EmptyPath_AppliesModifyToRoot()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem { globalOrbitSpeedMultiplier = 1f, globalSizeMultiplier = 1f };
+            object? obj = system;
+
+            var patch = new SerializedMember { typeName = typeof(SolarSystem).GetTypeId() ?? string.Empty };
+            patch.SetFieldValue(reflector, "globalOrbitSpeedMultiplier", 42f);
+
+            var logs = new Logs();
+            var success = reflector.TryModifyAt(ref obj, "", patch, logs: logs);
+
+            _output.WriteLine(logs.ToString());
+            Assert.True(success);
+            Assert.Equal(42f, ((SolarSystem)obj!).globalOrbitSpeedMultiplier);
+            Assert.Equal(1f,  ((SolarSystem)obj!).globalSizeMultiplier); // untouched
+        }
+
         // ─── Test-local helper types ───────────────────────────────────────────────
 
         private class DictionaryContainer
@@ -372,6 +543,26 @@ namespace com.IvanMurzak.ReflectorNet.Tests.ReflectorTests
         private class IntDictionaryContainer
         {
             public Dictionary<int, string> lookup = new Dictionary<int, string>();
+        }
+
+        private class ListContainer
+        {
+            public List<SolarSystem.CelestialBody> bodies = new List<SolarSystem.CelestialBody>();
+        }
+
+        private class Animal
+        {
+            public string name = string.Empty;
+        }
+
+        private class Dog : Animal
+        {
+            public string breed = string.Empty;
+        }
+
+        private class AnimalContainer
+        {
+            public Animal? animal;
         }
     }
 }

--- a/ReflectorNet.Tests/src/ReflectorTests/AtomicModifyTests.cs
+++ b/ReflectorNet.Tests/src/ReflectorTests/AtomicModifyTests.cs
@@ -533,6 +533,244 @@ namespace com.IvanMurzak.ReflectorNet.Tests.ReflectorTests
             Assert.Equal(1f,  ((SolarSystem)obj!).globalSizeMultiplier); // untouched
         }
 
+        // ─── TryModifyAt — null at intermediate path ──────────────────────────────
+
+        [Fact]
+        public void TryModifyAt_NullAtIntermediatePath_ReturnsFalse()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem { sun = null }; // sun is null
+            object? obj = system;
+            var logs = new Logs();
+
+            // Trying to navigate sun/instanceID when sun is null
+            var success = reflector.TryModifyAt<int>(ref obj, "sun/instanceID", 99, logs: logs);
+
+            Assert.False(success);
+            var logsText = logs.ToString();
+            _output.WriteLine(logsText);
+            Assert.Contains("null", logsText);
+            // Original object must be untouched
+            Assert.Null(((SolarSystem)obj!).sun);
+        }
+
+        // ─── TryModifyAt — negative array index ───────────────────────────────────
+
+        [Fact]
+        public void TryModifyAt_NegativeIndex_ReturnsFalse()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem
+            {
+                celestialBodies = new[]
+                {
+                    new SolarSystem.CelestialBody { orbitRadius = 10f }
+                }
+            };
+            object? obj = system;
+            var logs = new Logs();
+
+            var success = reflector.TryModifyAt<float>(ref obj, "celestialBodies/[-1]/orbitRadius", 0f, logs: logs);
+
+            Assert.False(success);
+            var logsText = logs.ToString();
+            _output.WriteLine(logsText);
+            Assert.Contains("out of range", logsText);
+            Assert.Equal(10f, ((SolarSystem)obj!).celestialBodies![0].orbitRadius); // untouched
+        }
+
+        // ─── TryModifyAt — dictionary missing key is added ────────────────────────
+        // TryLookupBracketedElement returns true for non-existing dict keys and
+        // provides a writeBack that adds the entry — unlike TryReadAt/TryNavigateOneSegment.
+
+        [Fact]
+        public void TryModifyAt_Dictionary_AddsNewKey_WhenKeyMissing()
+        {
+            var reflector = new Reflector();
+            var container = new DictionaryContainer
+            {
+                config = new Dictionary<string, int> { ["timeout"] = 10 }
+            };
+            object? obj = container;
+            var logs = new Logs();
+
+            var success = reflector.TryModifyAt<int>(ref obj, "config/[newKey]", 42, logs: logs);
+
+            _output.WriteLine(logs.ToString());
+            Assert.True(success);
+            var result = (DictionaryContainer)obj!;
+            Assert.True(result.config.ContainsKey("newKey"));
+            Assert.Equal(42, result.config["newKey"]);
+            Assert.Equal(10, result.config["timeout"]); // untouched
+        }
+
+        // ─── TryModifyAt — dict key type-conversion failure ───────────────────────
+
+        [Fact]
+        public void TryModifyAt_DictKeyTypeConversionFailure_ReturnsFalse()
+        {
+            var reflector = new Reflector();
+            var container = new IntDictionaryContainer
+            {
+                lookup = new Dictionary<int, string> { [1] = "one" }
+            };
+            object? obj = container;
+            var logs = new Logs();
+
+            // "notAnInt" cannot be converted to the key type int
+            var success = reflector.TryModifyAt<string>(ref obj, "lookup/[notAnInt]", "value", logs: logs);
+
+            Assert.False(success);
+            var logsText = logs.ToString();
+            _output.WriteLine(logsText);
+            Assert.Contains("notAnInt", logsText);
+        }
+
+        // ─── TryModifyAt — bracket notation on non-collection type ────────────────
+
+        [Fact]
+        public void TryModifyAt_BracketOnNonCollection_ReturnsFalse()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem { globalOrbitSpeedMultiplier = 1f };
+            object? obj = system;
+            var logs = new Logs();
+
+            // globalOrbitSpeedMultiplier is a float — [0] makes no sense
+            var success = reflector.TryModifyAt<float>(ref obj, "globalOrbitSpeedMultiplier/[0]", 5f, logs: logs);
+
+            Assert.False(success);
+            var logsText = logs.ToString();
+            _output.WriteLine(logsText);
+            Assert.Contains("[0]", logsText);
+        }
+
+        // ─── TryModifyAt — read-only property returns false ───────────────────────
+
+        [Fact]
+        public void TryModifyAt_ReadOnlyProperty_ReturnsFalse()
+        {
+            var reflector = new Reflector();
+            var container = new ReadOnlyPropertyContainer();
+            object? obj = container;
+            var logs = new Logs();
+
+            var success = reflector.TryModifyAt<float>(ref obj, "ReadOnlyValue", 99f, logs: logs);
+
+            Assert.False(success);
+            var logsText = logs.ToString();
+            _output.WriteLine(logsText);
+            Assert.Contains("read-only", logsText);
+            Assert.Equal(42f, ((ReadOnlyPropertyContainer)obj!).ReadOnlyValue); // unchanged
+        }
+
+        // ─── TryModifyAt — mixed dict + array nesting ────────────────────────────
+
+        [Fact]
+        public void TryModifyAt_MixedDictAndArrayNesting()
+        {
+            var reflector = new Reflector();
+            var container = new DictOfArraysContainer
+            {
+                groups = new Dictionary<string, SolarSystem.CelestialBody[]>
+                {
+                    ["alpha"] = new[]
+                    {
+                        new SolarSystem.CelestialBody { orbitRadius = 10f, orbitSpeed = 1f },
+                        new SolarSystem.CelestialBody { orbitRadius = 20f, orbitSpeed = 2f },
+                    }
+                }
+            };
+            object? obj = container;
+
+            // Navigate: groups → [alpha] → [0] → orbitRadius
+            var success = reflector.TryModifyAt<float>(ref obj, "groups/[alpha]/[0]/orbitRadius", 99f);
+
+            Assert.True(success);
+            var result = (DictOfArraysContainer)obj!;
+            Assert.Equal(99f, result.groups["alpha"][0].orbitRadius);
+            Assert.Equal(1f,  result.groups["alpha"][0].orbitSpeed);  // untouched
+            Assert.Equal(20f, result.groups["alpha"][1].orbitRadius); // untouched
+        }
+
+        // ─── TryPatch — invalid JSON returns false ────────────────────────────────
+
+        [Fact]
+        public void TryPatch_InvalidJson_ReturnsFalse()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem { globalOrbitSpeedMultiplier = 1f };
+            object? obj = system;
+            var logs = new Logs();
+
+            var success = reflector.TryPatch(ref obj, "{ this is not valid json }", logs: logs);
+
+            Assert.False(success);
+            var logsText = logs.ToString();
+            _output.WriteLine(logsText);
+            Assert.Contains("Failed to parse JSON patch", logsText);
+            Assert.Equal(1f, ((SolarSystem)obj!).globalOrbitSpeedMultiplier); // unchanged
+        }
+
+        // ─── TryPatch — four-level deep patch via array bracket notation ──────────
+
+        [Fact]
+        public void TryPatch_FourLevelDeepPatch_ViaArray()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem
+            {
+                celestialBodies = new[]
+                {
+                    new SolarSystem.CelestialBody
+                    {
+                        orbitRadius = 10f,
+                        orbitTilt   = new Vector3(1f, 2f, 3f)
+                    }
+                }
+            };
+            object? obj = system;
+
+            // celestialBodies → [0] → orbitTilt → x (4 levels)
+            var json = @"{
+                ""celestialBodies"": {
+                    ""[0]"": {
+                        ""orbitTilt"": {
+                            ""x"": 99.0
+                        }
+                    }
+                }
+            }";
+
+            var logs = new Logs();
+            var success = reflector.TryPatch(ref obj, json, logs: logs);
+
+            _output.WriteLine(logs.ToString());
+            Assert.True(success);
+            var result = (SolarSystem)obj!;
+            Assert.Equal(99f, result.celestialBodies![0].orbitTilt.x);
+            Assert.Equal(2f,  result.celestialBodies![0].orbitTilt.y); // untouched
+            Assert.Equal(3f,  result.celestialBodies![0].orbitTilt.z); // untouched
+            Assert.Equal(10f, result.celestialBodies![0].orbitRadius);  // untouched
+        }
+
+        // ─── TryPatch — null JSON at root sets object to null ─────────────────────
+
+        [Fact]
+        public void TryPatch_NullAtRoot_SetsObjectToNull()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem { globalOrbitSpeedMultiplier = 2f };
+            object? obj = system;
+            var logs = new Logs();
+
+            var success = reflector.TryPatch(ref obj, "null", logs: logs);
+
+            _output.WriteLine(logs.ToString());
+            Assert.True(success);
+            Assert.Null(obj);
+        }
+
         // ─── Test-local helper types ───────────────────────────────────────────────
 
         private class DictionaryContainer
@@ -563,6 +801,18 @@ namespace com.IvanMurzak.ReflectorNet.Tests.ReflectorTests
         private class AnimalContainer
         {
             public Animal? animal;
+        }
+
+        private class ReadOnlyPropertyContainer
+        {
+            public float ReadOnlyValue { get; } = 42f; // no setter — CanWrite == false
+            public float WritableValue { get; set; } = 1f;
+        }
+
+        private class DictOfArraysContainer
+        {
+            public Dictionary<string, SolarSystem.CelestialBody[]> groups
+                = new Dictionary<string, SolarSystem.CelestialBody[]>();
         }
     }
 }

--- a/ReflectorNet.Tests/src/ReflectorTests/AtomicModifyTests.cs
+++ b/ReflectorNet.Tests/src/ReflectorTests/AtomicModifyTests.cs
@@ -1,0 +1,377 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using com.IvanMurzak.ReflectorNet.Model;
+using com.IvanMurzak.ReflectorNet.Tests.Model;
+using com.IvanMurzak.ReflectorNet.Utils;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace com.IvanMurzak.ReflectorNet.Tests.ReflectorTests
+{
+    public class AtomicModifyTests : BaseTest
+    {
+        public AtomicModifyTests(ITestOutputHelper output) : base(output) { }
+
+        // ─── TryModifyAt — root field ─────────────────────────────────────────────
+
+        [Fact]
+        public void TryModifyAt_RootField()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem { globalOrbitSpeedMultiplier = 1f, globalSizeMultiplier = 2f };
+            object? obj = system;
+
+            var success = reflector.TryModifyAt<float>(ref obj, "globalOrbitSpeedMultiplier", 5f);
+
+            Assert.True(success);
+            var result = (SolarSystem)obj!;
+            Assert.Equal(5f, result.globalOrbitSpeedMultiplier);
+            Assert.Equal(2f, result.globalSizeMultiplier); // untouched
+        }
+
+        // ─── TryModifyAt — two-level nested field ─────────────────────────────────
+
+        [Fact]
+        public void TryModifyAt_TwoLevelField_Property()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem { sun = new GameObjectRef { instanceID = 1 } };
+            object? obj = system;
+
+            var success = reflector.TryModifyAt<int>(ref obj, "sun/instanceID", 99);
+
+            Assert.True(success);
+            Assert.Equal(99, ((SolarSystem)obj!).sun!.instanceID);
+        }
+
+        // ─── TryModifyAt — array element field ────────────────────────────────────
+
+        [Fact]
+        public void TryModifyAt_ArrayElementField()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem
+            {
+                celestialBodies = new[]
+                {
+                    new SolarSystem.CelestialBody { orbitRadius = 10f, orbitSpeed = 1f },
+                    new SolarSystem.CelestialBody { orbitRadius = 20f, orbitSpeed = 2f },
+                }
+            };
+            object? obj = system;
+
+            // Modify only [0].orbitRadius — nothing else should change
+            var success = reflector.TryModifyAt<float>(ref obj, "celestialBodies/[0]/orbitRadius", 999f);
+
+            Assert.True(success);
+            var result = (SolarSystem)obj!;
+            Assert.Equal(999f, result.celestialBodies![0].orbitRadius);
+            Assert.Equal(1f,   result.celestialBodies![0].orbitSpeed);  // untouched
+            Assert.Equal(20f,  result.celestialBodies![1].orbitRadius); // untouched
+            Assert.Equal(2f,   result.celestialBodies![1].orbitSpeed);  // untouched
+
+            _output.WriteLine($"celestialBodies[0].orbitRadius = {result.celestialBodies[0].orbitRadius}");
+        }
+
+        // ─── TryModifyAt — partial update of array element (SerializedMember) ─────
+
+        [Fact]
+        public void TryModifyAt_PartialPatch_ArrayElement()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem
+            {
+                celestialBodies = new[]
+                {
+                    new SolarSystem.CelestialBody { orbitRadius = 10f, orbitSpeed = 3f },
+                    new SolarSystem.CelestialBody { orbitRadius = 20f, orbitSpeed = 4f },
+                }
+            };
+            object? obj = system;
+
+            // Navigate to [1] and apply a partial patch — only orbitRadius changes
+            var patch = new SerializedMember { typeName = typeof(SolarSystem.CelestialBody).GetTypeId() ?? string.Empty };
+            patch.SetFieldValue(reflector, "orbitRadius", 777f);
+
+            var logs = new Logs();
+            var success = reflector.TryModifyAt(ref obj, "celestialBodies/[1]", patch, logs: logs);
+
+            _output.WriteLine(logs.ToString());
+            Assert.True(success);
+            var result = (SolarSystem)obj!;
+            Assert.Equal(777f, result.celestialBodies![1].orbitRadius);
+            Assert.Equal(4f,   result.celestialBodies![1].orbitSpeed);  // untouched
+            Assert.Equal(10f,  result.celestialBodies![0].orbitRadius); // untouched
+        }
+
+        // ─── TryModifyAt — invalid member — detailed error ────────────────────────
+
+        [Fact]
+        public void TryModifyAt_InvalidMember_DetailedError()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem { globalOrbitSpeedMultiplier = 1f };
+            object? obj = system;
+            var logs = new Logs();
+
+            var success = reflector.TryModifyAt<float>(ref obj, "doesNotExist", 5f, logs: logs);
+
+            Assert.False(success);
+            var logsText = logs.ToString();
+            _output.WriteLine(logsText);
+            Assert.Contains("doesNotExist", logsText);
+            Assert.Contains("not found", logsText);
+        }
+
+        [Fact]
+        public void TryModifyAt_NestedInvalidSegment_DetailedError()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem { sun = new GameObjectRef { instanceID = 1 } };
+            object? obj = system;
+            var logs = new Logs();
+
+            var success = reflector.TryModifyAt<int>(ref obj, "sun/badSegment", 0, logs: logs);
+
+            Assert.False(success);
+            var logsText = logs.ToString();
+            _output.WriteLine(logsText);
+            Assert.Contains("badSegment", logsText);
+        }
+
+        // ─── TryModifyAt — out-of-bounds index — detailed error ───────────────────
+
+        [Fact]
+        public void TryModifyAt_OutOfBoundsIndex_DetailedError()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem
+            {
+                celestialBodies = new[]
+                {
+                    new SolarSystem.CelestialBody { orbitRadius = 1f },
+                    new SolarSystem.CelestialBody { orbitRadius = 2f },
+                }
+            };
+            object? obj = system;
+            var logs = new Logs();
+
+            var success = reflector.TryModifyAt<float>(ref obj, "celestialBodies/[99]/orbitRadius", 0f, logs: logs);
+
+            Assert.False(success);
+            var logsText = logs.ToString();
+            _output.WriteLine(logsText);
+            Assert.Contains("[99]", logsText);
+            Assert.Contains("out of range", logsText);
+            // Array should be unchanged
+            Assert.Equal(1f, ((SolarSystem)obj!).celestialBodies![0].orbitRadius);
+        }
+
+        // ─── TryModifyAt — Dictionary (string key) ────────────────────────────────
+
+        [Fact]
+        public void TryModifyAt_DictionaryStringKey()
+        {
+            var reflector = new Reflector();
+
+            var container = new DictionaryContainer
+            {
+                config = new Dictionary<string, int> { ["timeout"] = 10, ["retries"] = 3 }
+            };
+            object? obj = container;
+
+            var success = reflector.TryModifyAt<int>(ref obj, "config/[timeout]", 60);
+
+            Assert.True(success);
+            var result = (DictionaryContainer)obj!;
+            Assert.Equal(60, result.config["timeout"]);
+            Assert.Equal(3,  result.config["retries"]); // untouched
+        }
+
+        // ─── TryModifyAt — Dictionary (integer key) ───────────────────────────────
+
+        [Fact]
+        public void TryModifyAt_DictionaryIntKey()
+        {
+            var reflector = new Reflector();
+
+            var container = new IntDictionaryContainer
+            {
+                lookup = new Dictionary<int, string> { [1] = "one", [2] = "two", [3] = "three" }
+            };
+            object? obj = container;
+
+            var success = reflector.TryModifyAt<string>(ref obj, "lookup/[2]", "TWO");
+
+            Assert.True(success);
+            var result = (IntDictionaryContainer)obj!;
+            Assert.Equal("TWO",   result.lookup[2]);
+            Assert.Equal("one",   result.lookup[1]); // untouched
+            Assert.Equal("three", result.lookup[3]); // untouched
+        }
+
+        // ─── TryModifyAt — generic overload (leaf value) ──────────────────────────
+
+        [Fact]
+        public void TryModifyAt_GenericOverload_LeafValue()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem { globalSizeMultiplier = 1f };
+            object? obj = system;
+
+            var success = reflector.TryModifyAt<float>(ref obj, "globalSizeMultiplier", 3.14f);
+
+            Assert.True(success);
+            Assert.Equal(3.14f, ((SolarSystem)obj!).globalSizeMultiplier, precision: 5);
+        }
+
+        // ─── TryModifyAt — hash-prefixed path ────────────────────────────────────
+
+        [Fact]
+        public void TryModifyAt_HashPrefixedPath_IsStripped()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem { globalOrbitSpeedMultiplier = 1f };
+            object? obj = system;
+
+            var success = reflector.TryModifyAt<float>(ref obj, "#/globalOrbitSpeedMultiplier", 7f);
+
+            Assert.True(success);
+            Assert.Equal(7f, ((SolarSystem)obj!).globalOrbitSpeedMultiplier);
+        }
+
+        // ─── ArrayReflectionConverter.TryModify — partial element via SerializedMember ──
+
+        [Fact]
+        public void ArrayConverter_PartialElementModify_ViaSerializedMember()
+        {
+            var reflector = new Reflector();
+            object? celestialBodies = new SolarSystem.CelestialBody[]
+            {
+                new SolarSystem.CelestialBody { orbitRadius = 10f, orbitSpeed = 1f },
+                new SolarSystem.CelestialBody { orbitRadius = 20f, orbitSpeed = 2f },
+            };
+
+            // Build a SerializedMember that only specifies element [1].orbitRadius
+            var elem1 = new SerializedMember
+            {
+                name = "[1]",
+                typeName = typeof(SolarSystem.CelestialBody).GetTypeId() ?? string.Empty
+            };
+            elem1.SetFieldValue(reflector, "orbitRadius", 88f);
+
+            var data = new SerializedMember
+            {
+                typeName = typeof(SolarSystem.CelestialBody[]).GetTypeId() ?? string.Empty
+            };
+            data.AddField(elem1);
+
+            var logs = new Logs();
+            var success = reflector.TryModify(ref celestialBodies, data, logs: logs);
+
+            _output.WriteLine(logs.ToString());
+            Assert.True(success);
+            var arr = (SolarSystem.CelestialBody[])celestialBodies!;
+            Assert.Equal(88f, arr[1].orbitRadius);
+            Assert.Equal(2f,  arr[1].orbitSpeed);  // untouched
+            Assert.Equal(10f, arr[0].orbitRadius); // untouched
+            Assert.Equal(1f,  arr[0].orbitSpeed);  // untouched
+        }
+
+        // ─── TryPatch — multiple fields at different depths ────────────────────────
+
+        [Fact]
+        public void TryPatch_MultipleFieldsAtOnce()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem
+            {
+                globalOrbitSpeedMultiplier = 1f,
+                globalSizeMultiplier = 1f,
+                celestialBodies = new[]
+                {
+                    new SolarSystem.CelestialBody { orbitRadius = 10f, orbitSpeed = 1f },
+                    new SolarSystem.CelestialBody { orbitRadius = 20f, orbitSpeed = 2f },
+                }
+            };
+            object? obj = system;
+
+            var json = @"{
+                ""globalOrbitSpeedMultiplier"": 5.0,
+                ""globalSizeMultiplier"": 2.0
+            }";
+
+            var logs = new Logs();
+            var success = reflector.TryPatch(ref obj, json, logs: logs);
+
+            _output.WriteLine(logs.ToString());
+            Assert.True(success);
+            var result = (SolarSystem)obj!;
+            Assert.Equal(5f, result.globalOrbitSpeedMultiplier);
+            Assert.Equal(2f, result.globalSizeMultiplier);
+            Assert.Equal(10f, result.celestialBodies![0].orbitRadius); // untouched
+        }
+
+        [Fact]
+        public void TryPatch_ArrayElementAndField()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem
+            {
+                celestialBodies = new[]
+                {
+                    new SolarSystem.CelestialBody { orbitRadius = 10f, orbitSpeed = 1f },
+                    new SolarSystem.CelestialBody { orbitRadius = 20f, orbitSpeed = 2f },
+                }
+            };
+            object? obj = system;
+
+            // Modify celestialBodies[0].orbitRadius via JSON patch
+            var json = @"{
+                ""celestialBodies"": {
+                    ""[0]"": {
+                        ""orbitRadius"": 42.0
+                    }
+                }
+            }";
+
+            var logs = new Logs();
+            var success = reflector.TryPatch(ref obj, json, logs: logs);
+
+            _output.WriteLine(logs.ToString());
+            Assert.True(success);
+            var result = (SolarSystem)obj!;
+            Assert.Equal(42f, result.celestialBodies![0].orbitRadius);
+            Assert.Equal(1f,  result.celestialBodies![0].orbitSpeed);  // untouched
+            Assert.Equal(20f, result.celestialBodies![1].orbitRadius); // untouched
+        }
+
+        [Fact]
+        public void TryPatch_JsonElement_Overload()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem { globalOrbitSpeedMultiplier = 1f };
+            object? obj = system;
+
+            using var doc = JsonDocument.Parse(@"{ ""globalOrbitSpeedMultiplier"": 9.0 }");
+            var logs = new Logs();
+            var success = reflector.TryPatch(ref obj, doc.RootElement, logs: logs);
+
+            _output.WriteLine(logs.ToString());
+            Assert.True(success);
+            Assert.Equal(9f, ((SolarSystem)obj!).globalOrbitSpeedMultiplier);
+        }
+
+        // ─── Test-local helper types ───────────────────────────────────────────────
+
+        private class DictionaryContainer
+        {
+            public Dictionary<string, int> config = new Dictionary<string, int>();
+        }
+
+        private class IntDictionaryContainer
+        {
+            public Dictionary<int, string> lookup = new Dictionary<int, string>();
+        }
+    }
+}

--- a/ReflectorNet.Tests/src/ReflectorTests/ViewTests.cs
+++ b/ReflectorNet.Tests/src/ReflectorTests/ViewTests.cs
@@ -1,0 +1,465 @@
+using System.Collections.Generic;
+using System.Linq;
+using com.IvanMurzak.ReflectorNet.Model;
+using com.IvanMurzak.ReflectorNet.Tests.Model;
+using Xunit.Abstractions;
+
+namespace com.IvanMurzak.ReflectorNet.Tests.ReflectorTests
+{
+    public class ViewTests : BaseTest
+    {
+        public ViewTests(ITestOutputHelper output) : base(output) { }
+
+        // ─── View — default (no query) ────────────────────────────────────────────
+
+        [Fact]
+        public void View_Default_MatchesSerialize()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem
+            {
+                globalOrbitSpeedMultiplier = 2f,
+                globalSizeMultiplier = 3f,
+                celestialBodies = new[]
+                {
+                    new SolarSystem.CelestialBody { orbitRadius = 10f, orbitSpeed = 1f }
+                }
+            };
+            object? obj = system;
+
+            var viewed = reflector.View(obj);
+            var serialized = reflector.Serialize(system);
+
+            Assert.NotNull(viewed);
+            Assert.Equal(serialized.typeName, viewed.typeName);
+            Assert.NotNull(viewed.fields);
+            Assert.Equal(serialized.fields?.Count, viewed.fields?.Count);
+        }
+
+        // ─── View — Path navigates to subtree ────────────────────────────────────
+
+        [Fact]
+        public void View_Path_ReturnsSubTree()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem
+            {
+                celestialBodies = new[]
+                {
+                    new SolarSystem.CelestialBody { orbitRadius = 42f, orbitSpeed = 7f },
+                    new SolarSystem.CelestialBody { orbitRadius = 99f, orbitSpeed = 9f },
+                }
+            };
+            object? obj = system;
+
+            var result = reflector.View(obj, new ViewQuery { Path = "celestialBodies/[0]" });
+
+            Assert.NotNull(result);
+            // Should have typeName of CelestialBody
+            Assert.Contains("CelestialBody", result.typeName);
+            // Should NOT contain data from [1]
+            var orbitRadius = result.fields?.FirstOrDefault(f => f.name == "orbitRadius");
+            Assert.NotNull(orbitRadius);
+            Assert.Equal(42f, orbitRadius.GetValue<float>(reflector));
+        }
+
+        // ─── View — MaxDepth = 0 strips all children ─────────────────────────────
+
+        [Fact]
+        public void View_MaxDepth_Zero_RootOnly()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem { globalOrbitSpeedMultiplier = 1f };
+            object? obj = system;
+
+            var result = reflector.View(obj, new ViewQuery { MaxDepth = 0 });
+
+            Assert.NotNull(result);
+            Assert.Contains("SolarSystem", result.typeName);
+            Assert.True(result.fields == null || result.fields.Count == 0,
+                "MaxDepth=0 should strip all nested fields");
+        }
+
+        // ─── View — MaxDepth = 1 keeps top-level fields, strips their children ───
+
+        [Fact]
+        public void View_MaxDepth_One_TopLevel()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem
+            {
+                celestialBodies = new[]
+                {
+                    new SolarSystem.CelestialBody { orbitRadius = 5f }
+                }
+            };
+            object? obj = system;
+
+            var result = reflector.View(obj, new ViewQuery { MaxDepth = 1 });
+
+            Assert.NotNull(result);
+            // celestialBodies field should be present ...
+            var bodiesField = result.fields?.FirstOrDefault(f => f.name == "celestialBodies");
+            Assert.NotNull(bodiesField);
+            // ... but its own fields should be stripped (MaxDepth=1 means children of root are visible, grandchildren stripped)
+            // The array element [0] field should have no further fields
+            var elem0 = bodiesField.fields?.FirstOrDefault();
+            if (elem0 != null)
+                Assert.True(elem0.fields == null || elem0.fields.Count == 0,
+                    "MaxDepth=1 means grandchildren are stripped");
+        }
+
+        // ─── View — NamePattern keeps only matching direct fields ────────────────
+        // Note: NamePattern filters the SerializedMember tree (fields/props).
+        // Array elements stored in valueJsonElement are not individually filterable via NamePattern;
+        // use Grep for deep pattern search across the live object graph.
+
+        [Fact]
+        public void View_NamePattern_SparseTree()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem
+            {
+                globalOrbitSpeedMultiplier = 2f,
+                globalSizeMultiplier = 3f,
+            };
+            object? obj = system;
+
+            // "globalOrbit" (contains match, case-insensitive regex) matches globalOrbitSpeedMultiplier
+            // but not globalSizeMultiplier, sun, or celestialBodies
+            var result = reflector.View(obj, new ViewQuery { NamePattern = "globalOrbit" });
+
+            Assert.NotNull(result);
+            // globalOrbitSpeedMultiplier should be present
+            var orbitField = result.fields?.FirstOrDefault(f => f.name == "globalOrbitSpeedMultiplier");
+            Assert.NotNull(orbitField);
+            // globalSizeMultiplier should be pruned (does not match "globalOrbit")
+            Assert.True(result.fields == null || result.fields.All(f => f.name != "globalSizeMultiplier"),
+                "globalSizeMultiplier should be pruned");
+        }
+
+        // ─── View — NamePattern with no matches returns root envelope ─────────────
+
+        [Fact]
+        public void View_NamePattern_NoMatch_EmptyEnvelope()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem { globalOrbitSpeedMultiplier = 1f };
+            object? obj = system;
+
+            var result = reflector.View(obj, new ViewQuery { NamePattern = "doesNotMatchAnything_xyz" });
+
+            Assert.NotNull(result);
+            Assert.Contains("SolarSystem", result.typeName);
+            Assert.True(result.fields == null || result.fields.Count == 0,
+                "No matching fields → empty envelope");
+        }
+
+        // ─── View — combined Path + NamePattern ───────────────────────────────────
+
+        [Fact]
+        public void View_CombinedPathAndPattern()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem
+            {
+                celestialBodies = new[]
+                {
+                    new SolarSystem.CelestialBody { orbitRadius = 7f, orbitSpeed = 2f, rotationSpeed = 9f }
+                }
+            };
+            object? obj = system;
+
+            // Navigate to [0] then filter by "^orbit"
+            var result = reflector.View(obj, new ViewQuery { Path = "celestialBodies/[0]", NamePattern = "^orbit" });
+
+            Assert.NotNull(result);
+            Assert.Contains("CelestialBody", result.typeName);
+            Assert.NotNull(result.fields);
+            Assert.True(result.fields.All(f => f.name == null || f.name.StartsWith("orbit")),
+                "Only orbit* fields should remain after pattern filter");
+            Assert.True(result.fields.All(f => f.name != "rotationSpeed"),
+                "rotationSpeed should be pruned");
+        }
+
+        // ─── TryReadAt — root field ───────────────────────────────────────────────
+
+        [Fact]
+        public void TryReadAt_RootField()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem { globalOrbitSpeedMultiplier = 5f };
+            object? obj = system;
+
+            var ok = reflector.TryReadAt(obj, "globalOrbitSpeedMultiplier", out var result);
+
+            Assert.True(ok);
+            Assert.NotNull(result);
+            Assert.Equal(5f, result.GetValue<float>(reflector));
+        }
+
+        // ─── TryReadAt — array element ────────────────────────────────────────────
+
+        [Fact]
+        public void TryReadAt_ArrayElement()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem
+            {
+                celestialBodies = new[]
+                {
+                    new SolarSystem.CelestialBody { orbitRadius = 10f, orbitSpeed = 3f },
+                    new SolarSystem.CelestialBody { orbitRadius = 20f, orbitSpeed = 4f },
+                }
+            };
+            object? obj = system;
+
+            var ok = reflector.TryReadAt(obj, "celestialBodies/[0]", out var result);
+
+            Assert.True(ok);
+            Assert.NotNull(result);
+            Assert.Contains("CelestialBody", result.typeName);
+            var orbitRadius = result.fields?.FirstOrDefault(f => f.name == "orbitRadius");
+            Assert.NotNull(orbitRadius);
+            Assert.Equal(10f, orbitRadius.GetValue<float>(reflector));
+        }
+
+        // ─── TryReadAt — nested field ─────────────────────────────────────────────
+
+        [Fact]
+        public void TryReadAt_NestedField()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem
+            {
+                celestialBodies = new[]
+                {
+                    new SolarSystem.CelestialBody { orbitRadius = 42f }
+                }
+            };
+            object? obj = system;
+
+            var ok = reflector.TryReadAt(obj, "celestialBodies/[0]/orbitRadius", out var result);
+
+            Assert.True(ok);
+            Assert.NotNull(result);
+            Assert.Equal(42f, result.GetValue<float>(reflector));
+        }
+
+        // ─── TryReadAt — dictionary string key ───────────────────────────────────
+
+        [Fact]
+        public void TryReadAt_DictionaryStringKey()
+        {
+            var reflector = new Reflector();
+            var container = new DictionaryContainer
+            {
+                config = new Dictionary<string, int> { ["timeout"] = 30, ["retries"] = 5 }
+            };
+            object? obj = container;
+
+            var ok = reflector.TryReadAt(obj, "config/[timeout]", out var result);
+
+            Assert.True(ok);
+            Assert.NotNull(result);
+            Assert.Equal(30, result.GetValue<int>(reflector));
+        }
+
+        // ─── TryReadAt — dictionary integer key ──────────────────────────────────
+
+        [Fact]
+        public void TryReadAt_DictionaryIntKey()
+        {
+            var reflector = new Reflector();
+            var container = new IntDictionaryContainer
+            {
+                lookup = new Dictionary<int, string> { [1] = "one", [2] = "two" }
+            };
+            object? obj = container;
+
+            var ok = reflector.TryReadAt(obj, "lookup/[2]", out var result);
+
+            Assert.True(ok);
+            Assert.NotNull(result);
+            Assert.Equal("two", result.GetValue<string>(reflector));
+        }
+
+        // ─── TryReadAt — invalid path returns false + logs ────────────────────────
+
+        [Fact]
+        public void TryReadAt_InvalidPath_ReturnsFalse()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem { globalOrbitSpeedMultiplier = 1f };
+            object? obj = system;
+            var logs = new Logs();
+
+            var ok = reflector.TryReadAt(obj, "doesNotExist", out var result, logs: logs);
+
+            Assert.False(ok);
+            Assert.Null(result);
+            var logsText = logs.ToString();
+            _output.WriteLine(logsText);
+            Assert.Contains("doesNotExist", logsText);
+            Assert.Contains("not found", logsText);
+        }
+
+        // ─── TryReadAt — out-of-bounds index returns false + logs ────────────────
+
+        [Fact]
+        public void TryReadAt_OutOfBounds_ReturnsFalse()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem
+            {
+                celestialBodies = new[]
+                {
+                    new SolarSystem.CelestialBody { orbitRadius = 1f }
+                }
+            };
+            object? obj = system;
+            var logs = new Logs();
+
+            var ok = reflector.TryReadAt(obj, "celestialBodies/[99]", out var result, logs: logs);
+
+            Assert.False(ok);
+            Assert.Null(result);
+            var logsText = logs.ToString();
+            _output.WriteLine(logsText);
+            Assert.Contains("[99]", logsText);
+            Assert.Contains("out of range", logsText);
+        }
+
+        // ─── Grep — simple pattern finds all matches ──────────────────────────────
+
+        [Fact]
+        public void Grep_SimplePattern_FindsAllMatches()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem
+            {
+                celestialBodies = new[]
+                {
+                    new SolarSystem.CelestialBody { orbitRadius = 10f, orbitSpeed = 1f },
+                    new SolarSystem.CelestialBody { orbitRadius = 20f, orbitSpeed = 2f },
+                }
+            };
+            object? obj = system;
+
+            var matches = reflector.Grep(obj, "^orbit");
+
+            _output.WriteLine($"Found {matches.Count} matches:");
+            foreach (var m in matches)
+                _output.WriteLine($"  {m.Path}");
+
+            Assert.True(matches.Count >= 4, "Expected at least orbitRadius and orbitSpeed for each of 2 bodies");
+            Assert.Contains(matches, m => m.Path.Contains("orbitRadius"));
+            Assert.Contains(matches, m => m.Path.Contains("orbitSpeed"));
+        }
+
+        // ─── Grep — maxDepth limits search ───────────────────────────────────────
+
+        [Fact]
+        public void Grep_MaxDepth_LimitsSearch()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem
+            {
+                globalOrbitSpeedMultiplier = 1f,
+                celestialBodies = new[]
+                {
+                    new SolarSystem.CelestialBody { orbitRadius = 10f }
+                }
+            };
+            object? obj = system;
+
+            // maxDepth=0 — only top-level fields of SolarSystem
+            var matchesDepth0 = reflector.Grep(obj, ".*", maxDepth: 0);
+            _output.WriteLine($"maxDepth=0 found {matchesDepth0.Count} matches");
+            foreach (var m in matchesDepth0)
+                _output.WriteLine($"  {m.Path}");
+
+            // Should include globalOrbitSpeedMultiplier, globalSizeMultiplier, sun, celestialBodies
+            // But NOT fields inside celestialBodies elements (those are at depth 2+)
+            Assert.True(matchesDepth0.All(m => !m.Path.Contains("/")),
+                "maxDepth=0 should return only root-level fields (no slashes in path)");
+        }
+
+        // ─── Grep — array elements found ─────────────────────────────────────────
+
+        [Fact]
+        public void Grep_ArrayElements_FindsMatches()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem
+            {
+                celestialBodies = new[]
+                {
+                    new SolarSystem.CelestialBody { orbitRadius = 10f },
+                    new SolarSystem.CelestialBody { orbitRadius = 20f },
+                    new SolarSystem.CelestialBody { orbitRadius = 30f },
+                }
+            };
+            object? obj = system;
+
+            var matches = reflector.Grep(obj, "^orbitRadius$");
+
+            _output.WriteLine($"Found {matches.Count} orbitRadius matches:");
+            foreach (var m in matches)
+                _output.WriteLine($"  {m.Path} = {m.Value.GetValue<float>(reflector)}");
+
+            Assert.Equal(3, matches.Count);
+            Assert.Contains(matches, m => m.Path.Contains("[0]") && m.Value.GetValue<float>(reflector) == 10f);
+            Assert.Contains(matches, m => m.Path.Contains("[1]") && m.Value.GetValue<float>(reflector) == 20f);
+            Assert.Contains(matches, m => m.Path.Contains("[2]") && m.Value.GetValue<float>(reflector) == 30f);
+        }
+
+        // ─── Grep — no matches returns empty list ─────────────────────────────────
+
+        [Fact]
+        public void Grep_NoMatches_ReturnsEmpty()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem { globalOrbitSpeedMultiplier = 1f };
+            object? obj = system;
+
+            var matches = reflector.Grep(obj, "thisFieldDoesNotExist_xyz");
+
+            Assert.Empty(matches);
+        }
+
+        // ─── Grep — dictionary field found ───────────────────────────────────────
+
+        [Fact]
+        public void Grep_DictionaryField_Found()
+        {
+            var reflector = new Reflector();
+            var container = new DictionaryContainer
+            {
+                config = new Dictionary<string, int> { ["timeout"] = 10 }
+            };
+            object? obj = container;
+
+            var matches = reflector.Grep(obj, "^config$");
+
+            _output.WriteLine($"Found {matches.Count} matches:");
+            foreach (var m in matches)
+                _output.WriteLine($"  {m.Path}");
+
+            Assert.True(matches.Count >= 1);
+            Assert.Contains(matches, m => m.Path == "config");
+        }
+
+        // ─── Test-local helper types ───────────────────────────────────────────────
+
+        private class DictionaryContainer
+        {
+            public Dictionary<string, int> config = new Dictionary<string, int>();
+        }
+
+        private class IntDictionaryContainer
+        {
+            public Dictionary<int, string> lookup = new Dictionary<int, string>();
+        }
+    }
+}

--- a/ReflectorNet.Tests/src/ReflectorTests/ViewTests.cs
+++ b/ReflectorNet.Tests/src/ReflectorTests/ViewTests.cs
@@ -547,6 +547,252 @@ namespace com.IvanMurzak.ReflectorNet.Tests.ReflectorTests
             Assert.Contains("Invalid regex pattern", logs.ToString());
         }
 
+        // ─── TryReadAt — null object returns false ────────────────────────────────
+
+        [Fact]
+        public void TryReadAt_NullObject_ReturnsFalse()
+        {
+            var reflector = new Reflector();
+            var logs = new Logs();
+
+            var ok = reflector.TryReadAt(null, "globalOrbitSpeedMultiplier", out var result, logs: logs);
+
+            Assert.False(ok);
+            Assert.Null(result);
+            var logsText = logs.ToString();
+            _output.WriteLine(logsText);
+            Assert.Contains("null", logsText);
+        }
+
+        // ─── TryReadAt — dictionary missing key returns false ────────────────────
+        // Unlike TryModifyAt (which adds the key via writeBack), TryReadAt uses
+        // TryNavigateOneSegment which explicitly checks dict.Contains and logs an error.
+
+        [Fact]
+        public void TryReadAt_DictionaryMissingKey_ReturnsFalse()
+        {
+            var reflector = new Reflector();
+            var container = new DictionaryContainer
+            {
+                config = new Dictionary<string, int> { ["timeout"] = 30 }
+            };
+            object? obj = container;
+            var logs = new Logs();
+
+            var ok = reflector.TryReadAt(obj, "config/[doesNotExist]", out var result, logs: logs);
+
+            Assert.False(ok);
+            Assert.Null(result);
+            var logsText = logs.ToString();
+            _output.WriteLine(logsText);
+            Assert.Contains("doesNotExist", logsText);
+        }
+
+        // ─── TryReadAt — bracket notation on non-collection type ─────────────────
+
+        [Fact]
+        public void TryReadAt_BracketOnNonCollection_ReturnsFalse()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem
+            {
+                celestialBodies = new[]
+                {
+                    new SolarSystem.CelestialBody { orbitRadius = 10f }
+                }
+            };
+            object? obj = system;
+            var logs = new Logs();
+
+            // orbitRadius is a float — [0] makes no sense on it
+            var ok = reflector.TryReadAt(obj, "celestialBodies/[0]/orbitRadius/[0]", out var result, logs: logs);
+
+            Assert.False(ok);
+            Assert.Null(result);
+            var logsText = logs.ToString();
+            _output.WriteLine(logsText);
+            Assert.Contains("[0]", logsText);
+        }
+
+        // ─── TryReadAt — hash-prefixed path is stripped ───────────────────────────
+
+        [Fact]
+        public void TryReadAt_HashPrefixedPath_IsStripped()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem { globalOrbitSpeedMultiplier = 7f };
+            object? obj = system;
+
+            var ok = reflector.TryReadAt(obj, "#/globalOrbitSpeedMultiplier", out var result);
+
+            Assert.True(ok);
+            Assert.NotNull(result);
+            Assert.Equal(7f, result.GetValue<float>(reflector));
+        }
+
+        // ─── Grep — circular reference does not cause infinite loop ───────────────
+
+        [Fact]
+        public void Grep_CircularReference_DoesNotLoop()
+        {
+            var reflector = new Reflector();
+            var node = new CircularNode { name = "root" };
+            node.next = node; // self-reference
+            object? obj = node;
+
+            // Should complete without StackOverflowException
+            var matches = reflector.Grep(obj, ".*");
+
+            _output.WriteLine($"Found {matches.Count} matches (circular ref guard):");
+            foreach (var m in matches)
+                _output.WriteLine($"  {m.Path}");
+
+            // At minimum, the direct fields of the root node should match
+            Assert.True(matches.Count >= 1, "At least one field should be found before circular ref guard fires");
+            Assert.Contains(matches, m => m.Path == "name" || m.Path == "next");
+        }
+
+        // ─── Grep — finds properties, not only fields ─────────────────────────────
+        // Vector3's x, y, z are properties (not fields). Grep should include them.
+
+        [Fact]
+        public void Grep_FindsProperties_NotJustFields()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem
+            {
+                celestialBodies = new[]
+                {
+                    new SolarSystem.CelestialBody { orbitTilt = new Vector3(5f, 6f, 7f) }
+                }
+            };
+            object? obj = system;
+
+            var matches = reflector.Grep(obj, "^x$");
+
+            _output.WriteLine($"Found {matches.Count} 'x' matches:");
+            foreach (var m in matches)
+                _output.WriteLine($"  {m.Path} = {m.Value.GetValue<float>(reflector)}");
+
+            Assert.True(matches.Count >= 1, "Property 'x' on Vector3 should be found by Grep");
+            Assert.Contains(matches, m => m.Path.Contains("/x") && m.Value.GetValue<float>(reflector) == 5f);
+        }
+
+        // ─── View — MaxDepth applied before NamePattern ───────────────────────────
+        // MaxDepth=1 prunes to top-level fields of SolarSystem. 'orbitRadius' lives
+        // inside celestialBodies elements (depth 3 in serialized tree), so it cannot
+        // survive the depth prune and will never match the pattern.
+
+        [Fact]
+        public void View_MaxDepthAndNamePatternCombined_DepthPruneFirst()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem
+            {
+                celestialBodies = new[]
+                {
+                    new SolarSystem.CelestialBody { orbitRadius = 42f }
+                }
+            };
+            object? obj = system;
+
+            // Depth=1 strips everything below the top-level fields.
+            // orbitRadius is at depth 3 (SolarSystem→celestialBodies[0]→orbitRadius),
+            // so after pruning it is gone before NamePattern even runs.
+            var result = reflector.View(obj, new ViewQuery { MaxDepth = 1, NamePattern = "^orbitRadius$" });
+
+            Assert.NotNull(result);
+            Assert.Contains("SolarSystem", result.typeName);
+            Assert.True(result.fields == null || result.fields.Count == 0,
+                "orbitRadius is beyond MaxDepth=1 and must not appear after NamePattern filter");
+        }
+
+        // ─── View — empty path string is equivalent to no path ───────────────────
+
+        [Fact]
+        public void View_EmptyPath_SameAsNoPath()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem
+            {
+                globalOrbitSpeedMultiplier = 3f,
+                celestialBodies = new[]
+                {
+                    new SolarSystem.CelestialBody { orbitRadius = 10f }
+                }
+            };
+            object? obj = system;
+
+            var withEmptyPath = reflector.View(obj, new ViewQuery { Path = "" });
+            var withNoQuery   = reflector.View(obj);
+
+            Assert.NotNull(withEmptyPath);
+            Assert.NotNull(withNoQuery);
+            Assert.Equal(withNoQuery.typeName, withEmptyPath.typeName);
+            Assert.Equal(withNoQuery.fields?.Count, withEmptyPath.fields?.Count);
+        }
+
+        // ─── Grep — finds matches inside List<T> elements ────────────────────────
+
+        [Fact]
+        public void Grep_FindsMatchesInsideListElements()
+        {
+            var reflector = new Reflector();
+            var container = new ListContainer
+            {
+                bodies = new List<SolarSystem.CelestialBody>
+                {
+                    new SolarSystem.CelestialBody { orbitRadius = 11f },
+                    new SolarSystem.CelestialBody { orbitRadius = 22f },
+                    new SolarSystem.CelestialBody { orbitRadius = 33f },
+                }
+            };
+            object? obj = container;
+
+            var matches = reflector.Grep(obj, "^orbitRadius$");
+
+            _output.WriteLine($"Found {matches.Count} orbitRadius matches in List<T>:");
+            foreach (var m in matches)
+                _output.WriteLine($"  {m.Path} = {m.Value.GetValue<float>(reflector)}");
+
+            Assert.Equal(3, matches.Count);
+            Assert.Contains(matches, m => m.Path.Contains("[0]") && m.Value.GetValue<float>(reflector) == 11f);
+            Assert.Contains(matches, m => m.Path.Contains("[1]") && m.Value.GetValue<float>(reflector) == 22f);
+            Assert.Contains(matches, m => m.Path.Contains("[2]") && m.Value.GetValue<float>(reflector) == 33f);
+        }
+
+        // ─── Grep — maxDepth=0 returns only root-level direct fields ─────────────
+        // At depth 0, Grep only matches fields of the root object itself.
+        // celestialBodies elements are at depth 2+ so they are skipped.
+
+        [Fact]
+        public void Grep_MaxDepthZero_SkipsNestedElements()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem
+            {
+                globalOrbitSpeedMultiplier = 1f,
+                celestialBodies = new[]
+                {
+                    new SolarSystem.CelestialBody { orbitRadius = 99f }
+                }
+            };
+            object? obj = system;
+
+            // Match everything — but maxDepth=0 limits us to SolarSystem's own fields only
+            var matchesAll = reflector.Grep(obj, ".*", maxDepth: 0);
+
+            _output.WriteLine($"maxDepth=0: {matchesAll.Count} matches");
+            foreach (var m in matchesAll)
+                _output.WriteLine($"  {m.Path}");
+
+            // None of the paths should contain a '/' (that would indicate nesting)
+            Assert.True(matchesAll.All(m => !m.Path.Contains("/")),
+                "maxDepth=0 must not return nested paths");
+            // orbitRadius (inside celestialBodies[0]) must not appear
+            Assert.DoesNotContain(matchesAll, m => m.Path.Contains("orbitRadius"));
+        }
+
         // ─── Test-local helper types ───────────────────────────────────────────────
 
         private class DictionaryContainer
@@ -557,6 +803,17 @@ namespace com.IvanMurzak.ReflectorNet.Tests.ReflectorTests
         private class IntDictionaryContainer
         {
             public Dictionary<int, string> lookup = new Dictionary<int, string>();
+        }
+
+        private class ListContainer
+        {
+            public List<SolarSystem.CelestialBody> bodies = new List<SolarSystem.CelestialBody>();
+        }
+
+        private class CircularNode
+        {
+            public string name = string.Empty;
+            public CircularNode? next;
         }
     }
 }

--- a/ReflectorNet.Tests/src/ReflectorTests/ViewTests.cs
+++ b/ReflectorNet.Tests/src/ReflectorTests/ViewTests.cs
@@ -89,6 +89,7 @@ namespace com.IvanMurzak.ReflectorNet.Tests.ReflectorTests
             var reflector = new Reflector();
             var system = new SolarSystem
             {
+                sun = new GameObjectRef { instanceID = 42 },
                 celestialBodies = new[]
                 {
                     new SolarSystem.CelestialBody { orbitRadius = 5f }
@@ -99,15 +100,15 @@ namespace com.IvanMurzak.ReflectorNet.Tests.ReflectorTests
             var result = reflector.View(obj, new ViewQuery { MaxDepth = 1 });
 
             Assert.NotNull(result);
-            // celestialBodies field should be present ...
+            // celestialBodies field should be present at depth 1
             var bodiesField = result.fields?.FirstOrDefault(f => f.name == "celestialBodies");
             Assert.NotNull(bodiesField);
-            // ... but its own fields should be stripped (MaxDepth=1 means children of root are visible, grandchildren stripped)
-            // The array element [0] field should have no further fields
-            var elem0 = bodiesField.fields?.FirstOrDefault();
-            if (elem0 != null)
-                Assert.True(elem0.fields == null || elem0.fields.Count == 0,
-                    "MaxDepth=1 means grandchildren are stripped");
+            // sun field (a GameObjectRef object) should be present at depth 1 ...
+            var sunField = result.fields?.FirstOrDefault(f => f.name == "sun");
+            Assert.NotNull(sunField);
+            // ... but sun's own properties (instanceID, path, name) are at depth 2 and must be stripped
+            Assert.True(sunField.props == null || sunField.props.Count == 0,
+                "MaxDepth=1 means sun's nested properties are stripped");
         }
 
         // ─── View — NamePattern keeps only matching direct fields ────────────────
@@ -470,7 +471,7 @@ namespace com.IvanMurzak.ReflectorNet.Tests.ReflectorTests
             Assert.NotNull(result);
             // All returned fields/props must resolve to float
             if (result.fields != null)
-                Assert.True(result.fields.All(f => f.typeName != null && f.typeName.Contains("Single") || f.typeName == "float"),
+                Assert.True(result.fields.All(f => f.typeName != null && (f.typeName.Contains("Single") || f.typeName == "float")),
                     "Only float fields should survive TypeFilter=float");
         }
 
@@ -488,6 +489,62 @@ namespace com.IvanMurzak.ReflectorNet.Tests.ReflectorTests
             Assert.Contains("SolarSystem", result.typeName);
             Assert.True(result.fields == null || result.fields.Count == 0,
                 "No matching type → empty envelope");
+        }
+
+        // ─── Grep — null input returns empty list ─────────────────────────────────
+
+        [Fact]
+        public void Grep_NullInput_ReturnsEmpty()
+        {
+            var reflector = new Reflector();
+            var matches = reflector.Grep(null, ".*");
+            Assert.Empty(matches);
+        }
+
+        // ─── View — null object with known type does not throw ────────────────────
+
+        [Fact]
+        public void View_NullObject_WithFallbackType_DoesNotThrow()
+        {
+            var reflector = new Reflector();
+            // Serialize requires at least a type when obj is null
+            var result = reflector.View(null, fallbackObjType: typeof(SolarSystem));
+            Assert.NotNull(result);
+        }
+
+        // ─── Grep — invalid regex logs error and returns empty ────────────────────
+
+        [Fact]
+        public void Grep_InvalidRegex_ReturnsEmpty()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem { globalOrbitSpeedMultiplier = 1f };
+            object? obj = system;
+            var logs = new Logs();
+
+            var matches = reflector.Grep(obj, "(invalid[", logs: logs);
+
+            Assert.Empty(matches);
+            Assert.Contains("Invalid regex pattern", logs.ToString());
+        }
+
+        // ─── View — invalid NamePattern logs error and returns root envelope ──────
+
+        [Fact]
+        public void View_InvalidNamePattern_ReturnsEnvelope()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem { globalOrbitSpeedMultiplier = 1f };
+            object? obj = system;
+            var logs = new Logs();
+
+            var result = reflector.View(obj, new ViewQuery { NamePattern = "(invalid[" }, logs: logs);
+
+            Assert.NotNull(result);
+            Assert.Contains("SolarSystem", result.typeName);
+            Assert.True(result.fields == null || result.fields.Count == 0,
+                "Invalid pattern → root envelope with empty fields");
+            Assert.Contains("Invalid regex pattern", logs.ToString());
         }
 
         // ─── Test-local helper types ───────────────────────────────────────────────

--- a/ReflectorNet.Tests/src/ReflectorTests/ViewTests.cs
+++ b/ReflectorNet.Tests/src/ReflectorTests/ViewTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using com.IvanMurzak.ReflectorNet.Model;
@@ -448,6 +449,45 @@ namespace com.IvanMurzak.ReflectorNet.Tests.ReflectorTests
 
             Assert.True(matches.Count >= 1);
             Assert.Contains(matches, m => m.Path == "config");
+        }
+
+        // ─── View — TypeFilter keeps only matching type branches ─────────────────
+
+        [Fact]
+        public void View_TypeFilter_KeepsMatchingBranches()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem
+            {
+                globalOrbitSpeedMultiplier = 2f,
+                globalSizeMultiplier = 3f,
+            };
+            object? obj = system;
+
+            // TypeFilter = float should keep only float fields and discard non-float ones
+            var result = reflector.View(obj, new ViewQuery { TypeFilter = typeof(float) });
+
+            Assert.NotNull(result);
+            // All returned fields/props must resolve to float
+            if (result.fields != null)
+                Assert.True(result.fields.All(f => f.typeName != null && f.typeName.Contains("Single") || f.typeName == "float"),
+                    "Only float fields should survive TypeFilter=float");
+        }
+
+        [Fact]
+        public void View_TypeFilter_NoMatch_EmptyEnvelope()
+        {
+            var reflector = new Reflector();
+            var system = new SolarSystem { globalOrbitSpeedMultiplier = 1f };
+            object? obj = system;
+
+            // Nothing in SolarSystem resolves to Guid
+            var result = reflector.View(obj, new ViewQuery { TypeFilter = typeof(Guid) });
+
+            Assert.NotNull(result);
+            Assert.Contains("SolarSystem", result.typeName);
+            Assert.True(result.fields == null || result.fields.Count == 0,
+                "No matching type → empty envelope");
         }
 
         // ─── Test-local helper types ───────────────────────────────────────────────

--- a/ReflectorNet/src/Converter/Reflection/ArrayReflectionConverter.Modify.cs
+++ b/ReflectorNet/src/Converter/Reflection/ArrayReflectionConverter.Modify.cs
@@ -7,7 +7,6 @@
 
 using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.Logging;

--- a/ReflectorNet/src/Converter/Reflection/ArrayReflectionConverter.Modify.cs
+++ b/ReflectorNet/src/Converter/Reflection/ArrayReflectionConverter.Modify.cs
@@ -1,0 +1,145 @@
+/*
+ * ReflectorNet
+ * Author: Ivan Murzak (https://github.com/IvanMurzak)
+ * Copyright (c) 2025 Ivan Murzak
+ * Licensed under the Apache License, Version 2.0. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Extensions.Logging;
+using com.IvanMurzak.ReflectorNet.Model;
+using com.IvanMurzak.ReflectorNet.Utils;
+
+namespace com.IvanMurzak.ReflectorNet.Converter
+{
+    public partial class ArrayReflectionConverter
+    {
+        /// <summary>
+        /// Overrides TryModify to support partial in-place modification of individual array/list elements
+        /// using [i]-indexed field names in data.fields (e.g. name="[2]"). When data.valueJsonElement is
+        /// present, falls back to full replacement (existing behaviour). When data.fields contains only
+        /// non-indexed names, also falls back to base (unchanged behaviour).
+        /// </summary>
+        public override bool TryModify(
+            Reflector reflector,
+            ref object? obj,
+            SerializedMember data,
+            Type type,
+            int depth = 0,
+            Logs? logs = null,
+            BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+            ILogger? logger = null)
+        {
+            // Full replacement requested — delegate to base (calls SetValue → TryDeserializeValueListInternal)
+            if (data.valueJsonElement.HasValue)
+                return base.TryModify(reflector, ref obj, data, type, depth, logs, flags, logger);
+
+            // Partition data.fields into indexed ([i]-named) and non-indexed
+            var indexedFields = data.fields?.Where(f => IsArrayIndexName(f?.name)).ToList();
+
+            // No indexed fields — let base handle (unchanged behaviour)
+            if (indexedFields == null || indexedFields.Count == 0)
+                return base.TryModify(reflector, ref obj, data, type, depth, logs, flags, logger);
+
+            if (obj == null)
+            {
+                logs?.Error($"Cannot modify array elements: array is null.", depth);
+                if (logger?.IsEnabled(LogLevel.Error) == true)
+                    logger.LogError($"{StringUtils.GetPadding(depth)}Cannot modify array elements: array is null.");
+                return false;
+            }
+
+            var elementType = TypeUtils.GetEnumerableItemType(type);
+            var overallSuccess = true;
+
+            if (obj is Array array)
+            {
+                foreach (var indexedField in indexedFields)
+                {
+                    var idx = ParseArrayIndex(indexedField.name!);
+                    if (idx < 0 || idx >= array.Length)
+                    {
+                        var msg = $"Bracket segment '[{idx}]' index out of range on type '{type.GetTypeShortName()}'. Array length is {array.Length}.";
+                        logs?.Error(msg, depth);
+                        if (logger?.IsEnabled(LogLevel.Error) == true)
+                            logger.LogError($"{StringUtils.GetPadding(depth)}{msg}");
+                        overallSuccess = false;
+                        continue;
+                    }
+
+                    var currentElement = array.GetValue(idx);
+                    var success = reflector.TryModify(
+                        ref currentElement,
+                        data: indexedField,
+                        fallbackObjType: elementType,
+                        depth: depth + 1,
+                        logs: logs,
+                        flags: flags,
+                        logger: logger);
+
+                    if (success)
+                        array.SetValue(currentElement, idx);
+
+                    overallSuccess &= success;
+                }
+            }
+            else if (obj is IList list)
+            {
+                foreach (var indexedField in indexedFields)
+                {
+                    var idx = ParseArrayIndex(indexedField.name!);
+                    if (idx < 0 || idx >= list.Count)
+                    {
+                        var msg = $"Bracket segment '[{idx}]' index out of range on type '{type.GetTypeShortName()}'. List count is {list.Count}.";
+                        logs?.Error(msg, depth);
+                        if (logger?.IsEnabled(LogLevel.Error) == true)
+                            logger.LogError($"{StringUtils.GetPadding(depth)}{msg}");
+                        overallSuccess = false;
+                        continue;
+                    }
+
+                    var currentElement = list[idx];
+                    var success = reflector.TryModify(
+                        ref currentElement,
+                        data: indexedField,
+                        fallbackObjType: elementType,
+                        depth: depth + 1,
+                        logs: logs,
+                        flags: flags,
+                        logger: logger);
+
+                    if (success)
+                        list[idx] = currentElement;
+
+                    overallSuccess &= success;
+                }
+            }
+            else
+            {
+                var msg = $"Cannot modify array elements: type '{type.GetTypeShortName()}' is not an array or list.";
+                logs?.Error(msg, depth);
+                if (logger?.IsEnabled(LogLevel.Error) == true)
+                    logger.LogError($"{StringUtils.GetPadding(depth)}{msg}");
+                return false;
+            }
+
+            return overallSuccess;
+        }
+
+        private static bool IsArrayIndexName(string? name)
+        {
+            if (string.IsNullOrEmpty(name) || name.Length < 3)
+                return false;
+            if (name[0] != '[' || name[name.Length - 1] != ']')
+                return false;
+            return int.TryParse(name.Substring(1, name.Length - 2), out _);
+        }
+
+        private static int ParseArrayIndex(string name)
+            => int.Parse(name.Substring(1, name.Length - 2));
+    }
+}

--- a/ReflectorNet/src/Converter/Reflection/Base/BaseReflectionConverter.Modify.cs
+++ b/ReflectorNet/src/Converter/Reflection/Base/BaseReflectionConverter.Modify.cs
@@ -101,7 +101,11 @@ namespace com.IvanMurzak.ReflectorNet.Converter
             }
 
             var overallSuccess = true;
-            if (AllowSetValue)
+            // Skip SetValue only when this is a partial-patch call: fields/props are present but no
+            // explicit value was supplied. When there are no fields/props and no valueJsonElement the
+            // intent is to SET the target to null (or its default), so SetValue must still run.
+            var hasFieldsOrProps = (data.fields?.Count > 0) || (data.props?.Count > 0);
+            if (AllowSetValue && (data.valueJsonElement.HasValue || !hasFieldsOrProps))
             {
                 try
                 {

--- a/ReflectorNet/src/Model/ViewQuery.cs
+++ b/ReflectorNet/src/Model/ViewQuery.cs
@@ -1,0 +1,75 @@
+/*
+ * ReflectorNet
+ * Author: Ivan Murzak (https://github.com/IvanMurzak)
+ * Copyright (c) 2025 Ivan Murzak
+ * Licensed under the Apache License, Version 2.0. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+
+namespace com.IvanMurzak.ReflectorNet.Model
+{
+    /// <summary>
+    /// Options for <see cref="Reflector.View"/> — controls which parts of the serialized data to return.
+    /// When no options are set, <c>View</c> is equivalent to <c>Serialize</c> (full tree returned).
+    /// </summary>
+    public class ViewQuery
+    {
+        /// <summary>
+        /// Navigate to this path first, then serialize only that subtree.
+        /// Uses the same format as TryReadAt / TryModifyAt:
+        ///   - Plain segment navigates a field or property (e.g. "admin/name")
+        ///   - [i] navigates an Array or IList element (e.g. "users/[2]/name")
+        ///   - [key] navigates a dictionary entry (e.g. "config/[timeout]")
+        ///   - Leading "#/" is stripped automatically (compatible with SerializationContext paths)
+        /// </summary>
+        public string? Path { get; set; }
+
+        /// <summary>
+        /// .NET regex pattern applied to field/property names (case-insensitive).
+        /// Only branches that contain at least one matching name are kept in the result tree.
+        /// A plain string like "orbitRadius" matches that name exactly; "orbit.*" matches all
+        /// field/property names that start with "orbit".
+        /// When no match is found anywhere, the root envelope is returned with empty fields/props
+        /// so that the caller can still inspect the root type.
+        /// </summary>
+        public string? NamePattern { get; set; }
+
+        /// <summary>
+        /// Maximum depth of the returned tree.
+        /// 0 = root typeName/value only — no nested fields or properties.
+        /// 1 = one level of fields/props visible, their children stripped.
+        /// null = unlimited depth (default).
+        /// </summary>
+        public int? MaxDepth { get; set; }
+
+        /// <summary>
+        /// When set, only members whose resolved typeName is assignable to this type are kept.
+        /// Non-matching branches are pruned; the root envelope is preserved even with no matches.
+        /// </summary>
+        public Type? TypeFilter { get; set; }
+    }
+
+    /// <summary>
+    /// A single result entry returned by <see cref="Reflector.Grep"/>.
+    /// Holds the full slash-delimited path to the matched field/property and its serialized value.
+    /// </summary>
+    public class ViewMatch
+    {
+        /// <summary>
+        /// Full path to the matched location, e.g. "celestialBodies/[0]/orbitRadius".
+        /// </summary>
+        public string Path { get; }
+
+        /// <summary>
+        /// Serialized value at the matched location.
+        /// </summary>
+        public SerializedMember Value { get; }
+
+        public ViewMatch(string path, SerializedMember value)
+        {
+            Path  = path;
+            Value = value;
+        }
+    }
+}

--- a/ReflectorNet/src/Model/ViewQuery.cs
+++ b/ReflectorNet/src/Model/ViewQuery.cs
@@ -6,6 +6,7 @@
  */
 
 using System;
+using System.ComponentModel;
 
 namespace com.IvanMurzak.ReflectorNet.Model
 {
@@ -23,6 +24,13 @@ namespace com.IvanMurzak.ReflectorNet.Model
         ///   - [key] navigates a dictionary entry (e.g. "config/[timeout]")
         ///   - Leading "#/" is stripped automatically (compatible with SerializationContext paths)
         /// </summary>
+        [Description(
+            "Navigate to this path first, then serialize only that subtree. " +
+            "Path segments are separated by '/'. " +
+            "Use '[i]' for array/list index (e.g. 'users/[2]/name') and '[key]' for dictionary entry (e.g. 'config/[timeout]'). " +
+            "A leading '#/' is stripped automatically. " +
+            "Examples: 'admin/name', 'users/[0]/email', 'config/[timeout]'. " +
+            "Leave null to start from the root object.")]
         public string? Path { get; set; }
 
         /// <summary>
@@ -33,6 +41,12 @@ namespace com.IvanMurzak.ReflectorNet.Model
         /// When no match is found anywhere, the root envelope is returned with empty fields/props
         /// so that the caller can still inspect the root type.
         /// </summary>
+        [Description(
+            "Case-insensitive .NET regex pattern matched against field and property names. " +
+            "Only branches containing at least one match are kept in the result tree. " +
+            "Examples: 'orbitRadius' (exact name), 'orbit.*' (prefix match), 'radius|speed' (either name). " +
+            "When nothing matches, the root envelope is returned with empty fields/props. " +
+            "Leave null to return all fields and properties without filtering.")]
         public string? NamePattern { get; set; }
 
         /// <summary>
@@ -41,12 +55,23 @@ namespace com.IvanMurzak.ReflectorNet.Model
         /// 1 = one level of fields/props visible, their children stripped.
         /// null = unlimited depth (default).
         /// </summary>
+        [Description(
+            "Maximum nesting depth of the returned serialized tree. " +
+            "0 = root type name and value only — no nested fields or properties. " +
+            "1 = one level of fields/props visible, their children stripped. " +
+            "2 = two levels visible, and so on. " +
+            "Leave null (default) for unlimited depth.")]
         public int? MaxDepth { get; set; }
 
         /// <summary>
         /// When set, only members whose resolved typeName is assignable to this type are kept.
         /// Non-matching branches are pruned; the root envelope is preserved even with no matches.
         /// </summary>
+        [Description(
+            "When set, prunes the result tree to members whose runtime type is assignable to this type. " +
+            "Non-matching branches are removed; the root envelope is always preserved. " +
+            "Examples: typeof(float) keeps only float fields, typeof(IEnumerable) keeps only collections. " +
+            "Leave null to include members of any type.")]
         public Type? TypeFilter { get; set; }
     }
 
@@ -59,11 +84,16 @@ namespace com.IvanMurzak.ReflectorNet.Model
         /// <summary>
         /// Full path to the matched location, e.g. "celestialBodies/[0]/orbitRadius".
         /// </summary>
+        [Description(
+            "Full slash-delimited path to the matched location within the object graph. " +
+            "Array elements use bracket notation. " +
+            "Examples: 'orbitRadius', 'celestialBodies/[0]/orbitRadius', 'config/[timeout]'.")]
         public string Path { get; }
 
         /// <summary>
         /// Serialized value at the matched location.
         /// </summary>
+        [Description("Serialized representation of the value found at the matched path.")]
         public SerializedMember Value { get; }
 
         public ViewMatch(string path, SerializedMember value)

--- a/ReflectorNet/src/Reflector/Reflector.ModifyAt.cs
+++ b/ReflectorNet/src/Reflector/Reflector.ModifyAt.cs
@@ -6,9 +6,6 @@
  */
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using com.IvanMurzak.ReflectorNet.Model;
 using com.IvanMurzak.ReflectorNet.Utils;
@@ -148,136 +145,14 @@ namespace com.IvanMurzak.ReflectorNet
             BindingFlags flags,
             ILogger? logger)
         {
-            var padding = StringUtils.GetPadding(depth);
-
-            if (obj is IList)
-            {
-                if (!int.TryParse(innerKey, out int idx))
-                {
-                    var msg = $"Bracket segment '{segment}' cannot be used as index on type '{objType.GetTypeShortName()}'. Expected integer index.";
-                    logs?.Error(msg, depth);
-                    if (logger?.IsEnabled(LogLevel.Error) == true)
-                        logger.LogError($"{padding}{msg}");
-                    return false;
-                }
-                return TryModifyAtArrayIndex(ref obj, segment, idx, remainingPath, value, objType, depth, logs, flags, logger);
-            }
-
-            if (TypeUtils.IsDictionary(objType))
-            {
-                var args = TypeUtils.GetDictionaryGenericArguments(objType);
-                var keyType = args?[0] ?? typeof(object);
-                var valType = args?[1] ?? typeof(object);
-
-                object dictKey;
-                try
-                {
-                    dictKey = Convert.ChangeType(innerKey, keyType);
-                }
-                catch (Exception ex)
-                {
-                    var msg = $"Bracket segment '{segment}' cannot be converted to key type '{keyType.GetTypeShortName()}' on type '{objType.GetTypeShortName()}': {ex.Message}";
-                    logs?.Error(msg, depth);
-                    if (logger?.IsEnabled(LogLevel.Error) == true)
-                        logger.LogError($"{padding}{msg}");
-                    return false;
-                }
-                return TryModifyAtDictKey(ref obj, segment, dictKey, remainingPath, value, valType, depth, logs, flags, logger);
-            }
-
-            {
-                var msg = $"Bracket segment '{segment}' cannot be used on type '{objType.GetTypeShortName()}'. Type is not an array, list, or dictionary.";
-                logs?.Error(msg, depth);
-                if (logger?.IsEnabled(LogLevel.Error) == true)
-                    logger.LogError($"{padding}{msg}");
+            if (!TryLookupBracketedElement(obj, segment, innerKey, objType, depth, logs, logger,
+                    out var currentElement, out var elementType, out var writeBack))
                 return false;
-            }
-        }
 
-        private bool TryModifyAtArrayIndex(
-            ref object? obj,
-            string segment,
-            int idx,
-            string remainingPath,
-            SerializedMember value,
-            Type objType,
-            int depth,
-            Logs? logs,
-            BindingFlags flags,
-            ILogger? logger)
-        {
-            var elementType = TypeUtils.GetEnumerableItemType(objType);
-            var padding = StringUtils.GetPadding(depth);
-
-            if (obj is Array array)
-            {
-                if (idx < 0 || idx >= array.Length)
-                {
-                    var msg = $"Bracket segment '{segment}' index out of range on type '{objType.GetTypeShortName()}'. Array length is {array.Length}.";
-                    logs?.Error(msg, depth);
-                    if (logger?.IsEnabled(LogLevel.Error) == true)
-                        logger.LogError($"{padding}{msg}");
-                    return false;
-                }
-
-                var currentElement = array.GetValue(idx);
-                ApplyTypeReplacementCheck(ref currentElement, value, elementType ?? typeof(object), remainingPath);
-
-                var success = TryModifyAt(ref currentElement, remainingPath, value, elementType, depth + 1, logs, flags, logger);
-                if (success)
-                    array.SetValue(currentElement, idx);
-                return success;
-            }
-
-            if (obj is IList list)
-            {
-                if (idx < 0 || idx >= list.Count)
-                {
-                    var msg = $"Bracket segment '{segment}' index out of range on type '{objType.GetTypeShortName()}'. List count is {list.Count}.";
-                    logs?.Error(msg, depth);
-                    if (logger?.IsEnabled(LogLevel.Error) == true)
-                        logger.LogError($"{padding}{msg}");
-                    return false;
-                }
-
-                var currentElement = list[idx];
-                ApplyTypeReplacementCheck(ref currentElement, value, elementType ?? typeof(object), remainingPath);
-
-                var success = TryModifyAt(ref currentElement, remainingPath, value, elementType, depth + 1, logs, flags, logger);
-                if (success)
-                    list[idx] = currentElement;
-                return success;
-            }
-
-            {
-                var msg = $"Bracket segment '{segment}' cannot be applied: type '{objType.GetTypeShortName()}' is not an array or list.";
-                logs?.Error(msg, depth);
-                if (logger?.IsEnabled(LogLevel.Error) == true)
-                    logger.LogError($"{padding}{msg}");
-                return false;
-            }
-        }
-
-        private bool TryModifyAtDictKey(
-            ref object? obj,
-            string segment,
-            object dictKey,
-            string remainingPath,
-            SerializedMember value,
-            Type valueType,
-            int depth,
-            Logs? logs,
-            BindingFlags flags,
-            ILogger? logger)
-        {
-            var dict = (IDictionary)obj!;
-            var currentElement = dict.Contains(dictKey) ? dict[dictKey] : null;
-
-            ApplyTypeReplacementCheck(ref currentElement, value, valueType, remainingPath);
-
-            var success = TryModifyAt(ref currentElement, remainingPath, value, valueType, depth + 1, logs, flags, logger);
+            ApplyTypeReplacementCheck(ref currentElement, value, elementType, remainingPath);
+            var success = TryModifyAt(ref currentElement, remainingPath, value, elementType, depth + 1, logs, flags, logger);
             if (success)
-                dict[dictKey] = currentElement;
+                writeBack!(currentElement);
             return success;
         }
 
@@ -294,58 +169,15 @@ namespace com.IvanMurzak.ReflectorNet
             BindingFlags flags,
             ILogger? logger)
         {
-            var padding = StringUtils.GetPadding(depth);
+            if (!TryLookupMember(obj, memberName, objType, flags, depth, logs, logger,
+                    out var currentValue, out var memberType, out var writeBack))
+                return false;
 
-            // Try field
-            var fieldInfo = TypeMemberUtils.GetField(objType, flags, memberName);
-            if (fieldInfo != null)
-            {
-                var currentValue = fieldInfo.GetValue(obj);
-                ApplyTypeReplacementCheck(ref currentValue, value, fieldInfo.FieldType, remainingPath);
-
-                var success = TryModifyAt(ref currentValue, remainingPath, value, fieldInfo.FieldType, depth + 1, logs, flags, logger);
-                if (success)
-                    fieldInfo.SetValue(obj, currentValue); // struct-safe write-back
-                return success;
-            }
-
-            // Try property
-            var propInfo = TypeMemberUtils.GetProperty(objType, flags, memberName);
-            if (propInfo != null)
-            {
-                if (!propInfo.CanWrite)
-                {
-                    var readOnlyMsg = $"Property '{memberName}' on type '{objType.GetTypeShortName()}' is read-only.";
-                    logs?.Error(readOnlyMsg, depth);
-                    if (logger?.IsEnabled(LogLevel.Error) == true)
-                        logger.LogError($"{padding}{readOnlyMsg}");
-                    return false;
-                }
-
-                var currentValue = propInfo.GetValue(obj);
-                ApplyTypeReplacementCheck(ref currentValue, value, propInfo.PropertyType, remainingPath);
-
-                var success = TryModifyAt(ref currentValue, remainingPath, value, propInfo.PropertyType, depth + 1, logs, flags, logger);
-                if (success)
-                    propInfo.SetValue(obj, currentValue);
-                return success;
-            }
-
-            // Neither field nor property found — detailed error with available members
-            var fieldNames = objType.GetFields(flags).Select(f => f.Name).ToList();
-            var propNames  = objType.GetProperties(flags).Select(p => p.Name).ToList();
-            var fieldsStr  = fieldNames.Count > 0 ? string.Join(", ", fieldNames) : "none";
-            var propsStr   = propNames.Count  > 0 ? string.Join(", ", propNames)  : "none";
-
-            var msg = $"Segment '{memberName}' not found on type '{objType.GetTypeShortName()}'."
-                    + $"\nAvailable fields: {fieldsStr}"
-                    + $"\nAvailable properties: {propsStr}";
-
-            logs?.Error(msg, depth);
-            if (logger?.IsEnabled(LogLevel.Error) == true)
-                logger.LogError($"{padding}{msg}");
-
-            return false;
+            ApplyTypeReplacementCheck(ref currentValue, value, memberType, remainingPath);
+            var success = TryModifyAt(ref currentValue, remainingPath, value, memberType, depth + 1, logs, flags, logger);
+            if (success)
+                writeBack!(currentValue);
+            return success;
         }
     }
 }

--- a/ReflectorNet/src/Reflector/Reflector.ModifyAt.cs
+++ b/ReflectorNet/src/Reflector/Reflector.ModifyAt.cs
@@ -1,0 +1,351 @@
+/*
+ * ReflectorNet
+ * Author: Ivan Murzak (https://github.com/IvanMurzak)
+ * Copyright (c) 2025 Ivan Murzak
+ * Licensed under the Apache License, Version 2.0. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using com.IvanMurzak.ReflectorNet.Model;
+using com.IvanMurzak.ReflectorNet.Utils;
+using Microsoft.Extensions.Logging;
+
+namespace com.IvanMurzak.ReflectorNet
+{
+    public partial class Reflector
+    {
+        /// <summary>
+        /// Navigates to a specific field, array element, or dictionary entry by path and modifies only that target.
+        /// This is a truly atomic modification — no other parts of the object graph are touched.
+        ///
+        /// Path format:
+        ///   - Plain segment: field or property name (e.g. "admin" or "admin/name")
+        ///   - [i] where obj is Array/IList: array index (e.g. "users/[2]/name")
+        ///   - [key] where obj is IDictionary: dictionary key (e.g. "config/[timeout]")
+        ///   - Leading "#/" stripped automatically (compatible with SerializationContext paths)
+        ///
+        /// Errors are accumulated in the optional Logs object; nothing is thrown.
+        /// </summary>
+        public bool TryModifyAt(
+            ref object? obj,
+            string path,
+            SerializedMember value,
+            Type? fallbackObjType = null,
+            int depth = 0,
+            Logs? logs = null,
+            BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+            ILogger? logger = null)
+        {
+            var segments = ParsePath(path);
+
+            // No segments left — this is the terminal: apply the modification
+            if (segments.Length == 0)
+                return TryModify(ref obj, value, fallbackObjType, depth, logs, flags, logger);
+
+            if (obj == null)
+            {
+                var msg = $"Cannot navigate path '{path}': object is null.";
+                logs?.Error(msg, depth);
+                if (logger?.IsEnabled(LogLevel.Error) == true)
+                    logger.LogError($"{StringUtils.GetPadding(depth)}{msg}");
+                return false;
+            }
+
+            var segment = segments[0];
+            var remainingPath = segments.Length > 1
+                ? string.Join("/", segments, 1, segments.Length - 1)
+                : string.Empty;
+
+            var objType = obj.GetType();
+
+            if (TryParseBracketSegment(segment, out var innerKey))
+                return TryModifyAtBracketed(ref obj, segment, innerKey, remainingPath, value, objType, depth, logs, flags, logger);
+
+            return TryModifyAtMember(ref obj, segment, remainingPath, value, objType, depth, logs, flags, logger);
+        }
+
+        /// <summary>
+        /// Convenience generic overload — ideal for modifying leaf/primitive values by path.
+        /// Internally creates a SerializedMember.FromValue&lt;T&gt; and calls the primary overload.
+        /// </summary>
+        public bool TryModifyAt<T>(
+            ref object? obj,
+            string path,
+            T value,
+            Type? fallbackObjType = null,
+            int depth = 0,
+            Logs? logs = null,
+            BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+            ILogger? logger = null)
+        {
+            var serializedValue = SerializedMember.FromValue<T>(this, value);
+            return TryModifyAt(ref obj, path, serializedValue, fallbackObjType, depth, logs, flags, logger);
+        }
+
+        // ─── Path parsing ────────────────────────────────────────────────────────────
+
+        private static string[] ParsePath(string? path)
+        {
+            if (string.IsNullOrEmpty(path))
+                return Array.Empty<string>();
+
+            // Strip leading "#/" or "#" (SerializationContext convention)
+            if (path.StartsWith("#/"))
+                path = path.Substring(2);
+            else if (path.StartsWith("#"))
+                path = path.Substring(1);
+
+            return path.Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+        }
+
+        internal static bool TryParseBracketSegment(string segment, out string innerKey)
+        {
+            if (segment.Length > 2 && segment[0] == '[' && segment[segment.Length - 1] == ']')
+            {
+                innerKey = segment.Substring(1, segment.Length - 2);
+                return true;
+            }
+            innerKey = string.Empty;
+            return false;
+        }
+
+        // ─── Type-replacement check ───────────────────────────────────────────────────
+
+        /// <summary>
+        /// At the terminal navigation step, if the SerializedMember requests a different (but compatible subtype)
+        /// than the current value's type, resets currentValue to null so TryModify will create a fresh instance.
+        /// </summary>
+        private void ApplyTypeReplacementCheck(ref object? currentValue, SerializedMember value, Type declaredType, string remainingPath)
+        {
+            if (!string.IsNullOrEmpty(remainingPath))
+                return;
+
+            var desiredType = TypeUtils.GetTypeWithNamePriority(value, declaredType, out _);
+            if (desiredType != null
+                && currentValue != null
+                && desiredType != currentValue.GetType()
+                && declaredType.IsAssignableFrom(desiredType))
+            {
+                currentValue = null; // force fresh instance creation in TryModify's null branch
+            }
+        }
+
+        // ─── Bracket navigation (array index / dict key) ─────────────────────────────
+
+        private bool TryModifyAtBracketed(
+            ref object? obj,
+            string segment,
+            string innerKey,
+            string remainingPath,
+            SerializedMember value,
+            Type objType,
+            int depth,
+            Logs? logs,
+            BindingFlags flags,
+            ILogger? logger)
+        {
+            var padding = StringUtils.GetPadding(depth);
+
+            if (obj is IList)
+            {
+                if (!int.TryParse(innerKey, out int idx))
+                {
+                    var msg = $"Bracket segment '{segment}' cannot be used as index on type '{objType.GetTypeShortName()}'. Expected integer index.";
+                    logs?.Error(msg, depth);
+                    if (logger?.IsEnabled(LogLevel.Error) == true)
+                        logger.LogError($"{padding}{msg}");
+                    return false;
+                }
+                return TryModifyAtArrayIndex(ref obj, segment, idx, remainingPath, value, objType, depth, logs, flags, logger);
+            }
+
+            if (TypeUtils.IsDictionary(objType))
+            {
+                var args = TypeUtils.GetDictionaryGenericArguments(objType);
+                var keyType = args?[0] ?? typeof(object);
+                var valType = args?[1] ?? typeof(object);
+
+                object dictKey;
+                try
+                {
+                    dictKey = Convert.ChangeType(innerKey, keyType);
+                }
+                catch (Exception ex)
+                {
+                    var msg = $"Bracket segment '{segment}' cannot be converted to key type '{keyType.GetTypeShortName()}' on type '{objType.GetTypeShortName()}': {ex.Message}";
+                    logs?.Error(msg, depth);
+                    if (logger?.IsEnabled(LogLevel.Error) == true)
+                        logger.LogError($"{padding}{msg}");
+                    return false;
+                }
+                return TryModifyAtDictKey(ref obj, segment, dictKey, remainingPath, value, valType, depth, logs, flags, logger);
+            }
+
+            {
+                var msg = $"Bracket segment '{segment}' cannot be used on type '{objType.GetTypeShortName()}'. Type is not an array, list, or dictionary.";
+                logs?.Error(msg, depth);
+                if (logger?.IsEnabled(LogLevel.Error) == true)
+                    logger.LogError($"{padding}{msg}");
+                return false;
+            }
+        }
+
+        private bool TryModifyAtArrayIndex(
+            ref object? obj,
+            string segment,
+            int idx,
+            string remainingPath,
+            SerializedMember value,
+            Type objType,
+            int depth,
+            Logs? logs,
+            BindingFlags flags,
+            ILogger? logger)
+        {
+            var elementType = TypeUtils.GetEnumerableItemType(objType);
+            var padding = StringUtils.GetPadding(depth);
+
+            if (obj is Array array)
+            {
+                if (idx < 0 || idx >= array.Length)
+                {
+                    var msg = $"Bracket segment '{segment}' index out of range on type '{objType.GetTypeShortName()}'. Array length is {array.Length}.";
+                    logs?.Error(msg, depth);
+                    if (logger?.IsEnabled(LogLevel.Error) == true)
+                        logger.LogError($"{padding}{msg}");
+                    return false;
+                }
+
+                var currentElement = array.GetValue(idx);
+                ApplyTypeReplacementCheck(ref currentElement, value, elementType ?? typeof(object), remainingPath);
+
+                var success = TryModifyAt(ref currentElement, remainingPath, value, elementType, depth + 1, logs, flags, logger);
+                if (success)
+                    array.SetValue(currentElement, idx);
+                return success;
+            }
+
+            if (obj is IList list)
+            {
+                if (idx < 0 || idx >= list.Count)
+                {
+                    var msg = $"Bracket segment '{segment}' index out of range on type '{objType.GetTypeShortName()}'. List count is {list.Count}.";
+                    logs?.Error(msg, depth);
+                    if (logger?.IsEnabled(LogLevel.Error) == true)
+                        logger.LogError($"{padding}{msg}");
+                    return false;
+                }
+
+                var currentElement = list[idx];
+                ApplyTypeReplacementCheck(ref currentElement, value, elementType ?? typeof(object), remainingPath);
+
+                var success = TryModifyAt(ref currentElement, remainingPath, value, elementType, depth + 1, logs, flags, logger);
+                if (success)
+                    list[idx] = currentElement;
+                return success;
+            }
+
+            {
+                var msg = $"Bracket segment '{segment}' cannot be applied: type '{objType.GetTypeShortName()}' is not an array or list.";
+                logs?.Error(msg, depth);
+                if (logger?.IsEnabled(LogLevel.Error) == true)
+                    logger.LogError($"{padding}{msg}");
+                return false;
+            }
+        }
+
+        private bool TryModifyAtDictKey(
+            ref object? obj,
+            string segment,
+            object dictKey,
+            string remainingPath,
+            SerializedMember value,
+            Type valueType,
+            int depth,
+            Logs? logs,
+            BindingFlags flags,
+            ILogger? logger)
+        {
+            var dict = (IDictionary)obj!;
+            var currentElement = dict.Contains(dictKey) ? dict[dictKey] : null;
+
+            ApplyTypeReplacementCheck(ref currentElement, value, valueType, remainingPath);
+
+            var success = TryModifyAt(ref currentElement, remainingPath, value, valueType, depth + 1, logs, flags, logger);
+            if (success)
+                dict[dictKey] = currentElement;
+            return success;
+        }
+
+        // ─── Member navigation (field / property) ────────────────────────────────────
+
+        private bool TryModifyAtMember(
+            ref object? obj,
+            string memberName,
+            string remainingPath,
+            SerializedMember value,
+            Type objType,
+            int depth,
+            Logs? logs,
+            BindingFlags flags,
+            ILogger? logger)
+        {
+            var padding = StringUtils.GetPadding(depth);
+
+            // Try field
+            var fieldInfo = TypeMemberUtils.GetField(objType, flags, memberName);
+            if (fieldInfo != null)
+            {
+                var currentValue = fieldInfo.GetValue(obj);
+                ApplyTypeReplacementCheck(ref currentValue, value, fieldInfo.FieldType, remainingPath);
+
+                var success = TryModifyAt(ref currentValue, remainingPath, value, fieldInfo.FieldType, depth + 1, logs, flags, logger);
+                if (success)
+                    fieldInfo.SetValue(obj, currentValue); // struct-safe write-back
+                return success;
+            }
+
+            // Try property
+            var propInfo = TypeMemberUtils.GetProperty(objType, flags, memberName);
+            if (propInfo != null)
+            {
+                if (!propInfo.CanWrite)
+                {
+                    var readOnlyMsg = $"Property '{memberName}' on type '{objType.GetTypeShortName()}' is read-only.";
+                    logs?.Error(readOnlyMsg, depth);
+                    if (logger?.IsEnabled(LogLevel.Error) == true)
+                        logger.LogError($"{padding}{readOnlyMsg}");
+                    return false;
+                }
+
+                var currentValue = propInfo.GetValue(obj);
+                ApplyTypeReplacementCheck(ref currentValue, value, propInfo.PropertyType, remainingPath);
+
+                var success = TryModifyAt(ref currentValue, remainingPath, value, propInfo.PropertyType, depth + 1, logs, flags, logger);
+                if (success)
+                    propInfo.SetValue(obj, currentValue);
+                return success;
+            }
+
+            // Neither field nor property found — detailed error with available members
+            var fieldNames = objType.GetFields(flags).Select(f => f.Name).ToList();
+            var propNames  = objType.GetProperties(flags).Select(p => p.Name).ToList();
+            var fieldsStr  = fieldNames.Count > 0 ? string.Join(", ", fieldNames) : "none";
+            var propsStr   = propNames.Count  > 0 ? string.Join(", ", propNames)  : "none";
+
+            var msg = $"Segment '{memberName}' not found on type '{objType.GetTypeShortName()}'."
+                    + $"\nAvailable fields: {fieldsStr}"
+                    + $"\nAvailable properties: {propsStr}";
+
+            logs?.Error(msg, depth);
+            if (logger?.IsEnabled(LogLevel.Error) == true)
+                logger.LogError($"{padding}{msg}");
+
+            return false;
+        }
+    }
+}

--- a/ReflectorNet/src/Reflector/Reflector.Navigate.cs
+++ b/ReflectorNet/src/Reflector/Reflector.Navigate.cs
@@ -1,0 +1,193 @@
+/*
+ * ReflectorNet
+ * Author: Ivan Murzak (https://github.com/IvanMurzak)
+ * Copyright (c) 2025 Ivan Murzak
+ * Licensed under the Apache License, Version 2.0. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections;
+using System.Linq;
+using System.Reflection;
+using com.IvanMurzak.ReflectorNet.Model;
+using com.IvanMurzak.ReflectorNet.Utils;
+using Microsoft.Extensions.Logging;
+
+namespace com.IvanMurzak.ReflectorNet
+{
+    public partial class Reflector
+    {
+        /// <summary>
+        /// Resolves a named field or property on <paramref name="obj"/>, returning its current value,
+        /// declared type, and a write-back action for struct-safe mutation. The read-only check for
+        /// properties is enforced here. Returns false and logs a detailed error if the member is not
+        /// found or is read-only.
+        /// </summary>
+        private static bool TryLookupMember(
+            object? obj,
+            string memberName,
+            Type objType,
+            BindingFlags flags,
+            int depth,
+            Logs? logs,
+            ILogger? logger,
+            out object? currentValue,
+            out Type memberType,
+            out Action<object?>? writeBack)
+        {
+            var padding = StringUtils.GetPadding(depth);
+
+            // Try field
+            var fieldInfo = TypeMemberUtils.GetField(objType, flags, memberName);
+            if (fieldInfo != null)
+            {
+                currentValue = fieldInfo.GetValue(obj);
+                memberType   = fieldInfo.FieldType;
+                writeBack    = v => fieldInfo.SetValue(obj, v);
+                return true;
+            }
+
+            // Try property
+            var propInfo = TypeMemberUtils.GetProperty(objType, flags, memberName);
+            if (propInfo != null)
+            {
+                if (!propInfo.CanWrite)
+                {
+                    var readOnlyMsg = $"Property '{memberName}' on type '{objType.GetTypeShortName()}' is read-only.";
+                    logs?.Error(readOnlyMsg, depth);
+                    if (logger?.IsEnabled(LogLevel.Error) == true)
+                        logger.LogError($"{padding}{readOnlyMsg}");
+                    currentValue = null;
+                    memberType   = propInfo.PropertyType;
+                    writeBack    = null;
+                    return false;
+                }
+
+                currentValue = propInfo.GetValue(obj);
+                memberType   = propInfo.PropertyType;
+                writeBack    = v => propInfo.SetValue(obj, v);
+                return true;
+            }
+
+            // Neither found — detailed error with available members
+            var fieldNames = objType.GetFields(flags).Select(f => f.Name).ToList();
+            var propNames  = objType.GetProperties(flags).Select(p => p.Name).ToList();
+            var fieldsStr  = fieldNames.Count > 0 ? string.Join(", ", fieldNames) : "none";
+            var propsStr   = propNames.Count  > 0 ? string.Join(", ", propNames)  : "none";
+
+            var msg = $"Segment '{memberName}' not found on type '{objType.GetTypeShortName()}'."
+                    + $"\nAvailable fields: {fieldsStr}"
+                    + $"\nAvailable properties: {propsStr}";
+
+            logs?.Error(msg, depth);
+            if (logger?.IsEnabled(LogLevel.Error) == true)
+                logger.LogError($"{padding}{msg}");
+
+            currentValue = null;
+            memberType   = typeof(object);
+            writeBack    = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Resolves a bracket-notation segment (<c>[i]</c> for array/list, <c>[key]</c> for dictionary)
+        /// on <paramref name="obj"/>, returning the current element, its declared type, and a write-back
+        /// action. Bounds and key-type validation are enforced; detailed errors are logged on failure.
+        /// </summary>
+        private static bool TryLookupBracketedElement(
+            object? obj,
+            string segment,
+            string innerKey,
+            Type objType,
+            int depth,
+            Logs? logs,
+            ILogger? logger,
+            out object? currentElement,
+            out Type elementType,
+            out Action<object?>? writeBack)
+        {
+            var padding = StringUtils.GetPadding(depth);
+            currentElement = null;
+            elementType    = typeof(object);
+            writeBack      = null;
+
+            if (obj is IList)
+            {
+                if (!int.TryParse(innerKey, out int idx))
+                {
+                    var msg = $"Bracket segment '{segment}' cannot be used as index on type '{objType.GetTypeShortName()}'. Expected integer index.";
+                    logs?.Error(msg, depth);
+                    if (logger?.IsEnabled(LogLevel.Error) == true)
+                        logger.LogError($"{padding}{msg}");
+                    return false;
+                }
+
+                elementType = TypeUtils.GetEnumerableItemType(objType) ?? typeof(object);
+
+                if (obj is Array array)
+                {
+                    if (idx < 0 || idx >= array.Length)
+                    {
+                        var msg = $"Bracket segment '{segment}' index out of range on type '{objType.GetTypeShortName()}'. Array length is {array.Length}.";
+                        logs?.Error(msg, depth);
+                        if (logger?.IsEnabled(LogLevel.Error) == true)
+                            logger.LogError($"{padding}{msg}");
+                        return false;
+                    }
+
+                    currentElement = array.GetValue(idx);
+                    writeBack      = v => array.SetValue(v, idx);
+                    return true;
+                }
+
+                var list = (IList)obj;
+                if (idx < 0 || idx >= list.Count)
+                {
+                    var msg = $"Bracket segment '{segment}' index out of range on type '{objType.GetTypeShortName()}'. List count is {list.Count}.";
+                    logs?.Error(msg, depth);
+                    if (logger?.IsEnabled(LogLevel.Error) == true)
+                        logger.LogError($"{padding}{msg}");
+                    return false;
+                }
+
+                currentElement = list[idx];
+                writeBack      = v => list[idx] = v;
+                return true;
+            }
+
+            if (TypeUtils.IsDictionary(objType))
+            {
+                var args    = TypeUtils.GetDictionaryGenericArguments(objType);
+                var keyType = args?[0] ?? typeof(object);
+                elementType = args?[1] ?? typeof(object);
+
+                object dictKey;
+                try
+                {
+                    dictKey = Convert.ChangeType(innerKey, keyType);
+                }
+                catch (Exception ex)
+                {
+                    var msg = $"Bracket segment '{segment}' cannot be converted to key type '{keyType.GetTypeShortName()}' on type '{objType.GetTypeShortName()}': {ex.Message}";
+                    logs?.Error(msg, depth);
+                    if (logger?.IsEnabled(LogLevel.Error) == true)
+                        logger.LogError($"{padding}{msg}");
+                    return false;
+                }
+
+                var dict   = (IDictionary)obj!;
+                currentElement = dict.Contains(dictKey) ? dict[dictKey] : null;
+                writeBack      = v => dict[dictKey] = v;
+                return true;
+            }
+
+            {
+                var msg = $"Bracket segment '{segment}' cannot be used on type '{objType.GetTypeShortName()}'. Type is not an array, list, or dictionary.";
+                logs?.Error(msg, depth);
+                if (logger?.IsEnabled(LogLevel.Error) == true)
+                    logger.LogError($"{padding}{msg}");
+                return false;
+            }
+        }
+    }
+}

--- a/ReflectorNet/src/Reflector/Reflector.Patch.cs
+++ b/ReflectorNet/src/Reflector/Reflector.Patch.cs
@@ -113,20 +113,36 @@ namespace com.IvanMurzak.ReflectorNet
                 typeHint = typeElement.GetString();
 
             // Apply type replacement if $type specifies a compatible subtype
+            var overallSuccess = true;
             if (typeHint != null)
             {
                 var desiredType = TypeUtils.GetType(typeHint);
                 var declaredType = objType ?? obj?.GetType();
-                if (desiredType != null
-                    && obj != null
-                    && desiredType != obj.GetType()
-                    && (declaredType == null || declaredType.IsAssignableFrom(desiredType)))
+                if (desiredType == null)
+                {
+                    var typeMsg = $"$type hint '{typeHint}' could not be resolved to a known type.";
+                    logs?.Error(typeMsg, depth);
+                    if (logger?.IsEnabled(LogLevel.Error) == true)
+                        logger.LogError($"{padding}{typeMsg}");
+                    overallSuccess = false;
+                }
+                else if (declaredType != null && !declaredType.IsAssignableFrom(desiredType))
+                {
+                    var typeMsg = $"$type hint '{typeHint}' ('{desiredType.GetTypeShortName()}') is not assignable to declared type '{declaredType.GetTypeShortName()}'.";
+                    logs?.Error(typeMsg, depth);
+                    if (logger?.IsEnabled(LogLevel.Error) == true)
+                        logger.LogError($"{padding}{typeMsg}");
+                    overallSuccess = false;
+                }
+                else if (obj != null && desiredType != obj.GetType())
                 {
                     obj = null;
                     objType = desiredType;
                 }
-                else if (desiredType != null && objType == null)
+                else if (objType == null || (obj == null && desiredType != objType))
                 {
+                    // obj was reset to null (by ApplyPatchTypeReplacement) and we have a declared type;
+                    // upgrade to the desired subtype so the fresh instance is created as the correct type.
                     objType = desiredType;
                 }
             }
@@ -155,7 +171,6 @@ namespace com.IvanMurzak.ReflectorNet
             }
 
             objType = obj.GetType();
-            var overallSuccess = true;
 
             foreach (var property in patch.EnumerateObject())
             {

--- a/ReflectorNet/src/Reflector/Reflector.Patch.cs
+++ b/ReflectorNet/src/Reflector/Reflector.Patch.cs
@@ -1,0 +1,436 @@
+/*
+ * ReflectorNet
+ * Author: Ivan Murzak (https://github.com/IvanMurzak)
+ * Copyright (c) 2025 Ivan Murzak
+ * Licensed under the Apache License, Version 2.0. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using com.IvanMurzak.ReflectorNet.Model;
+using com.IvanMurzak.ReflectorNet.Utils;
+using Microsoft.Extensions.Logging;
+
+namespace com.IvanMurzak.ReflectorNet
+{
+    public partial class Reflector
+    {
+        /// <summary>
+        /// Applies a JSON Merge Patch document to an object, modifying multiple fields at different depths in
+        /// a single call. Follows RFC 7396 JSON Merge Patch semantics, extended with bracket-notation keys
+        /// for array/dictionary access.
+        ///
+        /// Patch document rules:
+        ///   - JSON object key   → navigate into that field/property (plain) or array/dict element (bracket)
+        ///   - JSON non-object   → set as the value at current node
+        ///   - JSON null         → set the field to null
+        ///   - "$type" key       → optional type hint: replace current instance with new type (must be a subtype
+        ///                         of the declared type). Other keys in the same object are then applied to the
+        ///                         fresh instance.
+        ///
+        /// Errors are accumulated in the optional Logs object; nothing is thrown.
+        /// </summary>
+        public bool TryPatch(
+            ref object? obj,
+            string json,
+            Type? fallbackObjType = null,
+            int depth = 0,
+            Logs? logs = null,
+            BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+            ILogger? logger = null)
+        {
+            JsonDocument doc;
+            try
+            {
+                doc = JsonDocument.Parse(json);
+            }
+            catch (Exception ex)
+            {
+                var msg = $"Failed to parse JSON patch: {ex.Message}";
+                logs?.Error(msg, depth);
+                if (logger?.IsEnabled(LogLevel.Error) == true)
+                    logger.LogError($"{StringUtils.GetPadding(depth)}{msg}");
+                return false;
+            }
+
+            using (doc)
+            {
+                return TryPatch(ref obj, doc.RootElement, fallbackObjType, depth, logs, flags, logger);
+            }
+        }
+
+        /// <summary>
+        /// Applies a JSON Merge Patch document to an object. See the string overload for full documentation.
+        /// </summary>
+        public bool TryPatch(
+            ref object? obj,
+            JsonElement patch,
+            Type? fallbackObjType = null,
+            int depth = 0,
+            Logs? logs = null,
+            BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+            ILogger? logger = null)
+        {
+            var objType = obj?.GetType() ?? fallbackObjType;
+            return TryPatchInternal(ref obj, patch, objType, depth, logs, flags, logger);
+        }
+
+        // ─── Internal recursive patch engine ─────────────────────────────────────────
+
+        private bool TryPatchInternal(
+            ref object? obj,
+            JsonElement patch,
+            Type? objType,
+            int depth,
+            Logs? logs,
+            BindingFlags flags,
+            ILogger? logger)
+        {
+            var padding = StringUtils.GetPadding(depth);
+
+            // null patch → set the current node to null
+            if (patch.ValueKind == JsonValueKind.Null)
+            {
+                obj = null;
+                return true;
+            }
+
+            // Leaf value (non-object JSON) → set directly via existing TryModify
+            if (patch.ValueKind != JsonValueKind.Object)
+            {
+                var member = SerializedMember.FromJson(objType ?? obj?.GetType() ?? typeof(object), patch);
+                return TryModify(ref obj, member, objType, depth, logs, flags, logger);
+            }
+
+            // JSON object → process optional "$type" hint first, then navigate keys
+
+            // Extract "$type" if present
+            string? typeHint = null;
+            if (patch.TryGetProperty("$type", out var typeElement))
+                typeHint = typeElement.GetString();
+
+            // Apply type replacement if $type specifies a compatible subtype
+            if (typeHint != null)
+            {
+                var desiredType = TypeUtils.GetType(typeHint);
+                var declaredType = objType ?? obj?.GetType();
+                if (desiredType != null
+                    && obj != null
+                    && desiredType != obj.GetType()
+                    && (declaredType == null || declaredType.IsAssignableFrom(desiredType)))
+                {
+                    obj = null;
+                    objType = desiredType;
+                }
+                else if (desiredType != null && objType == null)
+                {
+                    objType = desiredType;
+                }
+            }
+
+            // If obj is null but we have a type, create a default instance so we can navigate into it
+            if (obj == null && objType != null)
+            {
+                obj = CreateInstance(objType);
+                if (obj == null)
+                {
+                    var msg = $"Cannot create instance of type '{objType.GetTypeShortName()}' for patch application.";
+                    logs?.Error(msg, depth);
+                    if (logger?.IsEnabled(LogLevel.Error) == true)
+                        logger.LogError($"{padding}{msg}");
+                    return false;
+                }
+            }
+
+            if (obj == null)
+            {
+                var msg = $"Cannot apply JSON patch: target object is null and no type is known.";
+                logs?.Error(msg, depth);
+                if (logger?.IsEnabled(LogLevel.Error) == true)
+                    logger.LogError($"{padding}{msg}");
+                return false;
+            }
+
+            objType = obj.GetType();
+            var overallSuccess = true;
+
+            foreach (var property in patch.EnumerateObject())
+            {
+                if (property.Name == "$type")
+                    continue; // already consumed above
+
+                bool success;
+                if (TryParseBracketSegment(property.Name, out var innerKey))
+                    success = TryPatchBracketed(ref obj, property.Name, innerKey, property.Value, objType, depth, logs, flags, logger);
+                else
+                    success = TryPatchMember(ref obj, property.Name, property.Value, objType, depth, logs, flags, logger);
+
+                overallSuccess &= success;
+            }
+
+            return overallSuccess;
+        }
+
+        // ─── Patch member navigation ──────────────────────────────────────────────────
+
+        private bool TryPatchMember(
+            ref object? obj,
+            string memberName,
+            JsonElement patchValue,
+            Type? objType,
+            int depth,
+            Logs? logs,
+            BindingFlags flags,
+            ILogger? logger)
+        {
+            if (objType == null || obj == null)
+            {
+                var msg = $"Cannot navigate to member '{memberName}': object is null.";
+                logs?.Error(msg, depth);
+                if (logger?.IsEnabled(LogLevel.Error) == true)
+                    logger.LogError($"{StringUtils.GetPadding(depth)}{msg}");
+                return false;
+            }
+
+            var padding = StringUtils.GetPadding(depth);
+
+            // Try field
+            var fieldInfo = TypeMemberUtils.GetField(objType, flags, memberName);
+            if (fieldInfo != null)
+            {
+                var currentValue = fieldInfo.GetValue(obj);
+                ApplyPatchTypeReplacement(ref currentValue, patchValue, fieldInfo.FieldType);
+
+                var childType = currentValue?.GetType() ?? fieldInfo.FieldType;
+                var success = TryPatchInternal(ref currentValue, patchValue, childType, depth + 1, logs, flags, logger);
+                if (success)
+                    fieldInfo.SetValue(obj, currentValue);
+                return success;
+            }
+
+            // Try property
+            var propInfo = TypeMemberUtils.GetProperty(objType, flags, memberName);
+            if (propInfo != null)
+            {
+                if (!propInfo.CanWrite)
+                {
+                    var readOnlyMsg = $"Property '{memberName}' on type '{objType.GetTypeShortName()}' is read-only.";
+                    logs?.Error(readOnlyMsg, depth);
+                    if (logger?.IsEnabled(LogLevel.Error) == true)
+                        logger.LogError($"{padding}{readOnlyMsg}");
+                    return false;
+                }
+
+                var currentValue = propInfo.GetValue(obj);
+                ApplyPatchTypeReplacement(ref currentValue, patchValue, propInfo.PropertyType);
+
+                var childType = currentValue?.GetType() ?? propInfo.PropertyType;
+                var success = TryPatchInternal(ref currentValue, patchValue, childType, depth + 1, logs, flags, logger);
+                if (success)
+                    propInfo.SetValue(obj, currentValue);
+                return success;
+            }
+
+            // Neither found — detailed error
+            var fieldNames = objType.GetFields(flags).Select(f => f.Name).ToList();
+            var propNames  = objType.GetProperties(flags).Select(p => p.Name).ToList();
+            var fieldsStr  = fieldNames.Count > 0 ? string.Join(", ", fieldNames) : "none";
+            var propsStr   = propNames.Count  > 0 ? string.Join(", ", propNames)  : "none";
+
+            var notFoundMsg = $"Segment '{memberName}' not found on type '{objType.GetTypeShortName()}'."
+                            + $"\nAvailable fields: {fieldsStr}"
+                            + $"\nAvailable properties: {propsStr}";
+
+            logs?.Error(notFoundMsg, depth);
+            if (logger?.IsEnabled(LogLevel.Error) == true)
+                logger.LogError($"{padding}{notFoundMsg}");
+
+            return false;
+        }
+
+        private bool TryPatchBracketed(
+            ref object? obj,
+            string segment,
+            string innerKey,
+            JsonElement patchValue,
+            Type? objType,
+            int depth,
+            Logs? logs,
+            BindingFlags flags,
+            ILogger? logger)
+        {
+            if (obj == null || objType == null)
+            {
+                var msg = $"Cannot navigate bracket segment '{segment}': object is null.";
+                logs?.Error(msg, depth);
+                if (logger?.IsEnabled(LogLevel.Error) == true)
+                    logger.LogError($"{StringUtils.GetPadding(depth)}{msg}");
+                return false;
+            }
+
+            var padding = StringUtils.GetPadding(depth);
+
+            if (obj is IList)
+            {
+                if (!int.TryParse(innerKey, out int idx))
+                {
+                    var msg = $"Bracket segment '{segment}' cannot be used as index on type '{objType.GetTypeShortName()}'. Expected integer index.";
+                    logs?.Error(msg, depth);
+                    if (logger?.IsEnabled(LogLevel.Error) == true)
+                        logger.LogError($"{padding}{msg}");
+                    return false;
+                }
+                return TryPatchArrayIndex(ref obj, segment, idx, patchValue, objType, depth, logs, flags, logger);
+            }
+
+            if (TypeUtils.IsDictionary(objType))
+            {
+                var args = TypeUtils.GetDictionaryGenericArguments(objType);
+                var keyType = args?[0] ?? typeof(object);
+                var valType = args?[1] ?? typeof(object);
+
+                object dictKey;
+                try
+                {
+                    dictKey = Convert.ChangeType(innerKey, keyType);
+                }
+                catch (Exception ex)
+                {
+                    var msg = $"Bracket segment '{segment}' cannot be converted to key type '{keyType.GetTypeShortName()}' on type '{objType.GetTypeShortName()}': {ex.Message}";
+                    logs?.Error(msg, depth);
+                    if (logger?.IsEnabled(LogLevel.Error) == true)
+                        logger.LogError($"{padding}{msg}");
+                    return false;
+                }
+                return TryPatchDictKey(ref obj, segment, dictKey, patchValue, valType, depth, logs, flags, logger);
+            }
+
+            {
+                var msg = $"Bracket segment '{segment}' cannot be used on type '{objType.GetTypeShortName()}'. Type is not an array, list, or dictionary.";
+                logs?.Error(msg, depth);
+                if (logger?.IsEnabled(LogLevel.Error) == true)
+                    logger.LogError($"{padding}{msg}");
+                return false;
+            }
+        }
+
+        private bool TryPatchArrayIndex(
+            ref object? obj,
+            string segment,
+            int idx,
+            JsonElement patchValue,
+            Type objType,
+            int depth,
+            Logs? logs,
+            BindingFlags flags,
+            ILogger? logger)
+        {
+            var elementType = TypeUtils.GetEnumerableItemType(objType);
+            var padding = StringUtils.GetPadding(depth);
+
+            if (obj is Array array)
+            {
+                if (idx < 0 || idx >= array.Length)
+                {
+                    var msg = $"Bracket segment '{segment}' index out of range on type '{objType.GetTypeShortName()}'. Array length is {array.Length}.";
+                    logs?.Error(msg, depth);
+                    if (logger?.IsEnabled(LogLevel.Error) == true)
+                        logger.LogError($"{padding}{msg}");
+                    return false;
+                }
+
+                var currentElement = array.GetValue(idx);
+                ApplyPatchTypeReplacement(ref currentElement, patchValue, elementType ?? typeof(object));
+
+                var childType = currentElement?.GetType() ?? elementType;
+                var success = TryPatchInternal(ref currentElement, patchValue, childType, depth + 1, logs, flags, logger);
+                if (success)
+                    array.SetValue(currentElement, idx);
+                return success;
+            }
+
+            if (obj is IList list)
+            {
+                if (idx < 0 || idx >= list.Count)
+                {
+                    var msg = $"Bracket segment '{segment}' index out of range on type '{objType.GetTypeShortName()}'. List count is {list.Count}.";
+                    logs?.Error(msg, depth);
+                    if (logger?.IsEnabled(LogLevel.Error) == true)
+                        logger.LogError($"{padding}{msg}");
+                    return false;
+                }
+
+                var currentElement = list[idx];
+                ApplyPatchTypeReplacement(ref currentElement, patchValue, elementType ?? typeof(object));
+
+                var childType = currentElement?.GetType() ?? elementType;
+                var success = TryPatchInternal(ref currentElement, patchValue, childType, depth + 1, logs, flags, logger);
+                if (success)
+                    list[idx] = currentElement;
+                return success;
+            }
+
+            {
+                var msg = $"Bracket segment '{segment}' cannot be applied: type '{objType.GetTypeShortName()}' is not an array or list.";
+                logs?.Error(msg, depth);
+                if (logger?.IsEnabled(LogLevel.Error) == true)
+                    logger.LogError($"{padding}{msg}");
+                return false;
+            }
+        }
+
+        private bool TryPatchDictKey(
+            ref object? obj,
+            string segment,
+            object dictKey,
+            JsonElement patchValue,
+            Type valueType,
+            int depth,
+            Logs? logs,
+            BindingFlags flags,
+            ILogger? logger)
+        {
+            var dict = (IDictionary)obj!;
+            var currentElement = dict.Contains(dictKey) ? dict[dictKey] : null;
+
+            ApplyPatchTypeReplacement(ref currentElement, patchValue, valueType);
+
+            var childType = currentElement?.GetType() ?? valueType;
+            var success = TryPatchInternal(ref currentElement, patchValue, childType, depth + 1, logs, flags, logger);
+            if (success)
+                dict[dictKey] = currentElement;
+            return success;
+        }
+
+        // ─── Type replacement for patch (uses "$type" from JsonElement) ──────────────
+
+        /// <summary>
+        /// Checks if the JSON patch value contains a "$type" key specifying a compatible subtype.
+        /// If so, resets currentValue to null so TryPatchInternal will create a fresh instance.
+        /// </summary>
+        private static void ApplyPatchTypeReplacement(ref object? currentValue, JsonElement patchValue, Type declaredType)
+        {
+            if (patchValue.ValueKind != JsonValueKind.Object)
+                return;
+
+            if (!patchValue.TryGetProperty("$type", out var typeElement))
+                return;
+
+            var typeName = typeElement.GetString();
+            if (string.IsNullOrEmpty(typeName))
+                return;
+
+            var desiredType = TypeUtils.GetType(typeName);
+            if (desiredType != null
+                && currentValue != null
+                && desiredType != currentValue.GetType()
+                && declaredType.IsAssignableFrom(desiredType))
+            {
+                currentValue = null; // force fresh instance creation
+            }
+        }
+    }
+}

--- a/ReflectorNet/src/Reflector/Reflector.ReadAt.cs
+++ b/ReflectorNet/src/Reflector/Reflector.ReadAt.cs
@@ -63,7 +63,7 @@ namespace com.IvanMurzak.ReflectorNet
         /// <paramref name="objType"/> to the value at that segment.
         /// Handles bracket notation ([i] for arrays/lists, [key] for dicts) and plain member names.
         /// </summary>
-        internal bool TryNavigateOneSegment(
+        private bool TryNavigateOneSegment(
             ref object? obj,
             ref Type? objType,
             string segment,

--- a/ReflectorNet/src/Reflector/Reflector.ReadAt.cs
+++ b/ReflectorNet/src/Reflector/Reflector.ReadAt.cs
@@ -1,0 +1,196 @@
+/*
+ * ReflectorNet
+ * Author: Ivan Murzak (https://github.com/IvanMurzak)
+ * Copyright (c) 2025 Ivan Murzak
+ * Licensed under the Apache License, Version 2.0. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections;
+using System.Linq;
+using System.Reflection;
+using com.IvanMurzak.ReflectorNet.Model;
+using com.IvanMurzak.ReflectorNet.Utils;
+using Microsoft.Extensions.Logging;
+
+namespace com.IvanMurzak.ReflectorNet
+{
+    public partial class Reflector
+    {
+        /// <summary>
+        /// Navigates to a specific field, array element, or dictionary entry by path and
+        /// serializes only that target — the read-side counterpart of TryModifyAt.
+        ///
+        /// Path format:
+        ///   - Plain segment: field or property name (e.g. "admin" or "admin/name")
+        ///   - [i] where obj is Array/IList: array index (e.g. "users/[2]/name")
+        ///   - [key] where obj is IDictionary: dictionary key (e.g. "config/[timeout]")
+        ///   - Leading "#/" stripped automatically (compatible with SerializationContext paths)
+        ///
+        /// Errors are accumulated in the optional Logs object; nothing is thrown.
+        /// </summary>
+        public bool TryReadAt(
+            object? obj,
+            string path,
+            out SerializedMember? result,
+            Type? fallbackObjType = null,
+            int depth = 0,
+            Logs? logs = null,
+            BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+            ILogger? logger = null)
+        {
+            var segments   = ParsePath(path);
+            var target     = obj;
+            var targetType = obj?.GetType() ?? fallbackObjType;
+
+            for (int i = 0; i < segments.Length; i++)
+            {
+                if (!TryNavigateOneSegment(ref target, ref targetType, segments[i], depth + i, logs, flags, logger))
+                {
+                    result = null;
+                    return false;
+                }
+            }
+
+            result = Serialize(target, targetType, depth: depth + segments.Length, logs: logs, flags: flags, logger: logger);
+            return true;
+        }
+
+        // ─── Shared path-navigation helper (used by TryReadAt and View) ───────────────
+
+        /// <summary>
+        /// Navigates one path segment in-place, updating <paramref name="obj"/> and
+        /// <paramref name="objType"/> to the value at that segment.
+        /// Handles bracket notation ([i] for arrays/lists, [key] for dicts) and plain member names.
+        /// </summary>
+        internal bool TryNavigateOneSegment(
+            ref object? obj,
+            ref Type? objType,
+            string segment,
+            int depth,
+            Logs? logs,
+            BindingFlags flags,
+            ILogger? logger)
+        {
+            var padding = StringUtils.GetPadding(depth);
+
+            if (obj == null)
+            {
+                var msg = $"Cannot navigate segment '{segment}': object is null.";
+                logs?.Error(msg, depth);
+                if (logger?.IsEnabled(LogLevel.Error) == true)
+                    logger.LogError($"{padding}{msg}");
+                return false;
+            }
+
+            var resolvedType = obj.GetType();
+
+            if (TryParseBracketSegment(segment, out var innerKey))
+            {
+                // ── Array / IList ──────────────────────────────────────────────────────
+                if (obj is IList list)
+                {
+                    if (!int.TryParse(innerKey, out int idx))
+                    {
+                        var msg = $"Bracket segment '{segment}' cannot be used as index on type '{resolvedType.GetTypeShortName()}'. Expected integer index.";
+                        logs?.Error(msg, depth);
+                        if (logger?.IsEnabled(LogLevel.Error) == true)
+                            logger.LogError($"{padding}{msg}");
+                        return false;
+                    }
+
+                    if (idx < 0 || idx >= list.Count)
+                    {
+                        var msg = $"Bracket segment '{segment}' index out of range on type '{resolvedType.GetTypeShortName()}'. Array/list length is {list.Count}.";
+                        logs?.Error(msg, depth);
+                        if (logger?.IsEnabled(LogLevel.Error) == true)
+                            logger.LogError($"{padding}{msg}");
+                        return false;
+                    }
+
+                    obj     = list[idx];
+                    objType = TypeUtils.GetEnumerableItemType(resolvedType);
+                    return true;
+                }
+
+                // ── Dictionary ────────────────────────────────────────────────────────
+                if (TypeUtils.IsDictionary(resolvedType))
+                {
+                    var args    = TypeUtils.GetDictionaryGenericArguments(resolvedType);
+                    var keyType = args?[0] ?? typeof(object);
+                    var valType = args?[1] ?? typeof(object);
+
+                    object dictKey;
+                    try
+                    {
+                        dictKey = Convert.ChangeType(innerKey, keyType);
+                    }
+                    catch (Exception ex)
+                    {
+                        var msg = $"Bracket segment '{segment}' cannot be converted to key type '{keyType.GetTypeShortName()}' on type '{resolvedType.GetTypeShortName()}': {ex.Message}";
+                        logs?.Error(msg, depth);
+                        if (logger?.IsEnabled(LogLevel.Error) == true)
+                            logger.LogError($"{padding}{msg}");
+                        return false;
+                    }
+
+                    var dict = (IDictionary)obj;
+                    if (!dict.Contains(dictKey))
+                    {
+                        var msg = $"Bracket segment '{segment}' key not found in dictionary of type '{resolvedType.GetTypeShortName()}'.";
+                        logs?.Error(msg, depth);
+                        if (logger?.IsEnabled(LogLevel.Error) == true)
+                            logger.LogError($"{padding}{msg}");
+                        return false;
+                    }
+
+                    obj     = dict[dictKey];
+                    objType = valType;
+                    return true;
+                }
+
+                // ── Neither array/list nor dictionary ─────────────────────────────────
+                {
+                    var msg = $"Bracket segment '{segment}' cannot be used on type '{resolvedType.GetTypeShortName()}'. Type is not an array, list, or dictionary.";
+                    logs?.Error(msg, depth);
+                    if (logger?.IsEnabled(LogLevel.Error) == true)
+                        logger.LogError($"{padding}{msg}");
+                    return false;
+                }
+            }
+
+            // ── Plain segment — try field, then property ───────────────────────────────
+            var fieldInfo = TypeMemberUtils.GetField(resolvedType, flags, segment);
+            if (fieldInfo != null)
+            {
+                obj     = fieldInfo.GetValue(obj);
+                objType = fieldInfo.FieldType;
+                return true;
+            }
+
+            var propInfo = TypeMemberUtils.GetProperty(resolvedType, flags, segment);
+            if (propInfo != null)
+            {
+                obj     = propInfo.GetValue(obj);
+                objType = propInfo.PropertyType;
+                return true;
+            }
+
+            // ── Not found — detailed error with available members ──────────────────────
+            var fieldNames = resolvedType.GetFields(flags).Select(f => f.Name).ToList();
+            var propNames  = resolvedType.GetProperties(flags).Select(p => p.Name).ToList();
+            var fieldsStr  = fieldNames.Count > 0 ? string.Join(", ", fieldNames) : "none";
+            var propsStr   = propNames.Count  > 0 ? string.Join(", ", propNames)  : "none";
+
+            var errorMsg = $"Segment '{segment}' not found on type '{resolvedType.GetTypeShortName()}'."
+                         + $"\nAvailable fields: {fieldsStr}"
+                         + $"\nAvailable properties: {propsStr}";
+
+            logs?.Error(errorMsg, depth);
+            if (logger?.IsEnabled(LogLevel.Error) == true)
+                logger.LogError($"{padding}{errorMsg}");
+
+            return false;
+        }
+    }
+}

--- a/ReflectorNet/src/Reflector/Reflector.ReadAt.cs
+++ b/ReflectorNet/src/Reflector/Reflector.ReadAt.cs
@@ -177,10 +177,12 @@ namespace com.IvanMurzak.ReflectorNet
             }
 
             // ── Not found — detailed error with available members ──────────────────────
-            var fieldNames = resolvedType.GetFields(flags).Select(f => f.Name).ToList();
-            var propNames  = resolvedType.GetProperties(flags).Select(p => p.Name).ToList();
-            var fieldsStr  = fieldNames.Count > 0 ? string.Join(", ", fieldNames) : "none";
-            var propsStr   = propNames.Count  > 0 ? string.Join(", ", propNames)  : "none";
+            var serializableFields = GetSerializableFields(resolvedType, flags, logger);
+            var serializableProps  = GetSerializableProperties(resolvedType, flags, logger);
+            var fieldsStr = serializableFields != null ? string.Join(", ", serializableFields.Select(f => f.Name)) : "none";
+            var propsStr  = serializableProps  != null ? string.Join(", ", serializableProps .Select(p => p.Name)) : "none";
+            if (fieldsStr.Length == 0) fieldsStr = "none";
+            if (propsStr .Length == 0) propsStr  = "none";
 
             var errorMsg = $"Segment '{segment}' not found on type '{resolvedType.GetTypeShortName()}'."
                          + $"\nAvailable fields: {fieldsStr}"

--- a/ReflectorNet/src/Reflector/Reflector.View.cs
+++ b/ReflectorNet/src/Reflector/Reflector.View.cs
@@ -68,8 +68,9 @@ namespace com.IvanMurzak.ReflectorNet
 
                 if (!string.IsNullOrEmpty(query.NamePattern))
                 {
-                    var filtered = FilterByNamePattern(serialized, query.NamePattern);
-                    // If nothing matched, return root envelope with empty fields/props
+                    var rx = TryCompilePattern(query.NamePattern, logs, depth);
+                    var filtered = rx != null ? FilterByNamePattern(serialized, rx) : null;
+                    // If nothing matched (or invalid pattern), return root envelope with empty fields/props
                     serialized = filtered ?? new SerializedMember { name = serialized.name, typeName = serialized.typeName };
                 }
 
@@ -91,6 +92,7 @@ namespace com.IvanMurzak.ReflectorNet
         /// beginning with "orbit". maxDepth limits how many levels deep the search recurses
         /// (null = unlimited).
         ///
+        /// An invalid regex pattern logs an error and returns an empty list; nothing is thrown.
         /// Errors are accumulated in the optional Logs object; nothing is thrown.
         /// </summary>
         public IReadOnlyList<ViewMatch> Grep(
@@ -103,9 +105,12 @@ namespace com.IvanMurzak.ReflectorNet
             BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
             ILogger? logger = null)
         {
+            var rx = TryCompilePattern(namePattern, logs, depth);
+            if (rx == null) return new List<ViewMatch>().AsReadOnly();
+
             var matches = new List<ViewMatch>();
             var visited = new HashSet<object>(ObjectReferenceEqualityComparer.Instance);
-            GrepWalk(obj, obj?.GetType() ?? fallbackObjType, namePattern, maxDepth, 0,
+            GrepWalk(obj, rx, maxDepth, 0,
                      string.Empty, matches, visited, depth, logs, flags, logger);
             return matches.AsReadOnly();
         }
@@ -114,8 +119,7 @@ namespace com.IvanMurzak.ReflectorNet
 
         private void GrepWalk(
             object? obj,
-            Type? objType,
-            string namePattern,
+            Regex rx,
             int? maxDepth,
             int currentDepth,
             string currentPath,
@@ -129,8 +133,7 @@ namespace com.IvanMurzak.ReflectorNet
             if (obj == null) return;
             if (maxDepth.HasValue && currentDepth > maxDepth.Value) return;
 
-            var resolvedType = obj.GetType() ?? objType;
-            if (resolvedType == null) return;
+            var resolvedType = obj.GetType();
 
             // Circular-reference guard for reference types
             if (!resolvedType.IsValueType)
@@ -141,11 +144,10 @@ namespace com.IvanMurzak.ReflectorNet
             // Arrays / IList — recurse into elements (name-match does not apply to index paths)
             if (obj is IList list)
             {
-                var elementType = TypeUtils.GetEnumerableItemType(resolvedType);
                 for (int i = 0; i < list.Count; i++)
                 {
                     var elemPath = currentPath.Length == 0 ? $"[{i}]" : $"{currentPath}/[{i}]";
-                    GrepWalk(list[i], elementType, namePattern, maxDepth, currentDepth + 1,
+                    GrepWalk(list[i], rx, maxDepth, currentDepth + 1,
                              elemPath, matches, visited, serializeDepth, logs, flags, logger);
                 }
                 return; // arrays also implement IEnumerable — skip field/dict scanning
@@ -163,7 +165,7 @@ namespace com.IvanMurzak.ReflectorNet
                     try { fieldValue = field.GetValue(obj); }
                     catch { continue; }
 
-                    if (Regex.IsMatch(field.Name, namePattern, RegexOptions.IgnoreCase))
+                    if (rx.IsMatch(field.Name))
                     {
                         var serialized = Serialize(fieldValue, field.FieldType, name: field.Name,
                                                    depth: serializeDepth, logs: logs, flags: flags, logger: logger);
@@ -172,7 +174,7 @@ namespace com.IvanMurzak.ReflectorNet
 
                     // Recurse into non-primitive types (IList is handled by GrepWalk's own guard at entry)
                     if (!TypeUtils.IsPrimitive(field.FieldType))
-                        GrepWalk(fieldValue, field.FieldType, namePattern, maxDepth, currentDepth + 1,
+                        GrepWalk(fieldValue, rx, maxDepth, currentDepth + 1,
                                  fieldPath, matches, visited, serializeDepth, logs, flags, logger);
                 }
             }
@@ -191,7 +193,7 @@ namespace com.IvanMurzak.ReflectorNet
                     try { propValue = prop.GetValue(obj); }
                     catch { continue; }
 
-                    if (Regex.IsMatch(prop.Name, namePattern, RegexOptions.IgnoreCase))
+                    if (rx.IsMatch(prop.Name))
                     {
                         var serialized = Serialize(propValue, prop.PropertyType, name: prop.Name,
                                                    depth: serializeDepth, logs: logs, flags: flags, logger: logger);
@@ -200,7 +202,7 @@ namespace com.IvanMurzak.ReflectorNet
 
                     // Recurse into non-primitive types
                     if (!TypeUtils.IsPrimitive(prop.PropertyType))
-                        GrepWalk(propValue, prop.PropertyType, namePattern, maxDepth, currentDepth + 1,
+                        GrepWalk(propValue, rx, maxDepth, currentDepth + 1,
                                  propPath, matches, visited, serializeDepth, logs, flags, logger);
                 }
             }
@@ -208,13 +210,11 @@ namespace com.IvanMurzak.ReflectorNet
             // Dictionaries — recurse into values (name-match does not apply to key paths)
             if (TypeUtils.IsDictionary(resolvedType))
             {
-                var args    = TypeUtils.GetDictionaryGenericArguments(resolvedType);
-                var valType = args?[1] ?? typeof(object);
                 var dict    = (IDictionary)obj;
                 foreach (var key in dict.Keys)
                 {
                     var valuePath = currentPath.Length == 0 ? $"[{key}]" : $"{currentPath}/[{key}]";
-                    GrepWalk(dict[key], valType, namePattern, maxDepth, currentDepth + 1,
+                    GrepWalk(dict[key], rx, maxDepth, currentDepth + 1,
                              valuePath, matches, visited, serializeDepth, logs, flags, logger);
                 }
             }
@@ -253,14 +253,14 @@ namespace com.IvanMurzak.ReflectorNet
 
         /// <summary>
         /// Keeps only branches containing at least one field/property whose name matches
-        /// <paramref name="pattern"/> (regex, case-insensitive).
+        /// <paramref name="rx"/> (case-insensitive, pre-compiled).
         /// Returns null when nothing in this subtree matches.
         /// </summary>
-        private static SerializedMember? FilterByNamePattern(SerializedMember m, string pattern)
+        private static SerializedMember? FilterByNamePattern(SerializedMember m, Regex rx)
         {
-            var selfMatch      = m.name != null && Regex.IsMatch(m.name, pattern, RegexOptions.IgnoreCase);
-            var filteredFields = FilterListByNamePattern(m.fields, pattern);
-            var filteredProps  = FilterListByNamePattern(m.props,  pattern);
+            var selfMatch      = m.name != null && rx.IsMatch(m.name);
+            var filteredFields = FilterListByNamePattern(m.fields, rx);
+            var filteredProps  = FilterListByNamePattern(m.props,  rx);
 
             if (!selfMatch && filteredFields == null && filteredProps == null)
                 return null;
@@ -275,14 +275,14 @@ namespace com.IvanMurzak.ReflectorNet
             };
         }
 
-        private static SerializedMemberList? FilterListByNamePattern(SerializedMemberList? list, string pattern)
+        private static SerializedMemberList? FilterListByNamePattern(SerializedMemberList? list, Regex rx)
         {
             if (list == null || list.Count == 0) return null;
 
             SerializedMemberList? result = null;
             foreach (var m in list)
             {
-                var filtered = FilterByNamePattern(m, pattern);
+                var filtered = FilterByNamePattern(m, rx);
                 if (filtered != null)
                 {
                     result ??= new SerializedMemberList();
@@ -332,6 +332,25 @@ namespace com.IvanMurzak.ReflectorNet
                 }
             }
             return result;
+        }
+
+        // ─── Regex helper ─────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Compiles <paramref name="pattern"/> as a case-insensitive regex.
+        /// Returns null and logs an error if the pattern is invalid; nothing is thrown.
+        /// </summary>
+        private static Regex? TryCompilePattern(string pattern, Logs? logs, int depth = 0)
+        {
+            try
+            {
+                return new Regex(pattern, RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            }
+            catch (ArgumentException ex)
+            {
+                logs?.Error($"Invalid regex pattern '{pattern}': {ex.Message}", depth);
+                return null;
+            }
         }
 
         // Comparer that uses object identity (ReferenceEquals) rather than value equality.

--- a/ReflectorNet/src/Reflector/Reflector.View.cs
+++ b/ReflectorNet/src/Reflector/Reflector.View.cs
@@ -22,11 +22,14 @@ namespace com.IvanMurzak.ReflectorNet
         /// Serializes the object (or a navigated subtree) with optional filtering.
         /// Without a query (or with an empty query) this is equivalent to Serialize().
         ///
-        /// ViewQuery options:
+        /// ViewQuery options (applied in this order):
         ///   Path        — navigate to a path first, then serialize only that subtree
         ///   MaxDepth    — prune the returned tree to N levels (0 = root typeName/value only)
         ///   NamePattern — keep only branches containing a field/property name matching a .NET regex
         ///   TypeFilter  — keep only branches whose typeName resolves to a type assignable to this
+        ///
+        /// Filter order matters: MaxDepth prunes the tree before NamePattern/TypeFilter are applied,
+        /// so members deeper than MaxDepth are excluded even if their name or type would match.
         ///
         /// Errors are accumulated in the optional Logs object; nothing is thrown.
         /// </summary>
@@ -118,7 +121,7 @@ namespace com.IvanMurzak.ReflectorNet
             string currentPath,
             List<ViewMatch> matches,
             HashSet<object> visited,
-            int depth,
+            int serializeDepth,
             Logs? logs,
             BindingFlags flags,
             ILogger? logger)
@@ -143,7 +146,7 @@ namespace com.IvanMurzak.ReflectorNet
                 {
                     var elemPath = currentPath.Length == 0 ? $"[{i}]" : $"{currentPath}/[{i}]";
                     GrepWalk(list[i], elementType, namePattern, maxDepth, currentDepth + 1,
-                             elemPath, matches, visited, depth, logs, flags, logger);
+                             elemPath, matches, visited, serializeDepth, logs, flags, logger);
                 }
                 return; // arrays also implement IEnumerable — skip field/dict scanning
             }
@@ -163,14 +166,14 @@ namespace com.IvanMurzak.ReflectorNet
                     if (Regex.IsMatch(field.Name, namePattern, RegexOptions.IgnoreCase))
                     {
                         var serialized = Serialize(fieldValue, field.FieldType, name: field.Name,
-                                                   depth: depth, logs: logs, flags: flags, logger: logger);
+                                                   depth: serializeDepth, logs: logs, flags: flags, logger: logger);
                         matches.Add(new ViewMatch(fieldPath, serialized));
                     }
 
                     // Recurse into non-primitive types (IList is handled by GrepWalk's own guard at entry)
                     if (!TypeUtils.IsPrimitive(field.FieldType))
                         GrepWalk(fieldValue, field.FieldType, namePattern, maxDepth, currentDepth + 1,
-                                 fieldPath, matches, visited, depth, logs, flags, logger);
+                                 fieldPath, matches, visited, serializeDepth, logs, flags, logger);
                 }
             }
 
@@ -191,14 +194,14 @@ namespace com.IvanMurzak.ReflectorNet
                     if (Regex.IsMatch(prop.Name, namePattern, RegexOptions.IgnoreCase))
                     {
                         var serialized = Serialize(propValue, prop.PropertyType, name: prop.Name,
-                                                   depth: depth, logs: logs, flags: flags, logger: logger);
+                                                   depth: serializeDepth, logs: logs, flags: flags, logger: logger);
                         matches.Add(new ViewMatch(propPath, serialized));
                     }
 
                     // Recurse into non-primitive types
                     if (!TypeUtils.IsPrimitive(prop.PropertyType))
                         GrepWalk(propValue, prop.PropertyType, namePattern, maxDepth, currentDepth + 1,
-                                 propPath, matches, visited, depth, logs, flags, logger);
+                                 propPath, matches, visited, serializeDepth, logs, flags, logger);
                 }
             }
 
@@ -212,7 +215,7 @@ namespace com.IvanMurzak.ReflectorNet
                 {
                     var valuePath = currentPath.Length == 0 ? $"[{key}]" : $"{currentPath}/[{key}]";
                     GrepWalk(dict[key], valType, namePattern, maxDepth, currentDepth + 1,
-                             valuePath, matches, visited, depth, logs, flags, logger);
+                             valuePath, matches, visited, serializeDepth, logs, flags, logger);
                 }
             }
         }

--- a/ReflectorNet/src/Reflector/Reflector.View.cs
+++ b/ReflectorNet/src/Reflector/Reflector.View.cs
@@ -1,0 +1,339 @@
+/*
+ * ReflectorNet
+ * Author: Ivan Murzak (https://github.com/IvanMurzak)
+ * Copyright (c) 2025 Ivan Murzak
+ * Licensed under the Apache License, Version 2.0. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using com.IvanMurzak.ReflectorNet.Model;
+using com.IvanMurzak.ReflectorNet.Utils;
+using Microsoft.Extensions.Logging;
+
+namespace com.IvanMurzak.ReflectorNet
+{
+    public partial class Reflector
+    {
+        /// <summary>
+        /// Serializes the object (or a navigated subtree) with optional filtering.
+        /// Without a query (or with an empty query) this is equivalent to Serialize().
+        ///
+        /// ViewQuery options:
+        ///   Path        — navigate to a path first, then serialize only that subtree
+        ///   MaxDepth    — prune the returned tree to N levels (0 = root typeName/value only)
+        ///   NamePattern — keep only branches containing a field/property name matching a .NET regex
+        ///   TypeFilter  — keep only branches whose typeName resolves to a type assignable to this
+        ///
+        /// Errors are accumulated in the optional Logs object; nothing is thrown.
+        /// </summary>
+        public SerializedMember? View(
+            object? obj,
+            ViewQuery? query = null,
+            Type? fallbackObjType = null,
+            int depth = 0,
+            Logs? logs = null,
+            BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+            ILogger? logger = null)
+        {
+            // Step 1: Navigate to path if specified
+            var target     = obj;
+            var targetType = obj?.GetType() ?? fallbackObjType;
+
+            if (!string.IsNullOrEmpty(query?.Path))
+            {
+                var segments = ParsePath(query!.Path);
+                for (int i = 0; i < segments.Length; i++)
+                {
+                    if (!TryNavigateOneSegment(ref target, ref targetType, segments[i], depth + i, logs, flags, logger))
+                        return null;
+                }
+                depth += segments.Length;
+            }
+
+            // Step 2: Serialize
+            var serialized = Serialize(target, targetType ?? fallbackObjType, depth: depth, logs: logs, flags: flags, logger: logger);
+
+            // Step 3: Apply filters
+            if (query != null)
+            {
+                if (query.MaxDepth.HasValue)
+                    serialized = PruneToDepth(serialized, query.MaxDepth.Value);
+
+                if (!string.IsNullOrEmpty(query.NamePattern))
+                {
+                    var filtered = FilterByNamePattern(serialized, query.NamePattern);
+                    // If nothing matched, return root envelope with empty fields/props
+                    serialized = filtered ?? new SerializedMember { name = serialized.name, typeName = serialized.typeName };
+                }
+
+                if (query.TypeFilter != null)
+                {
+                    var filtered = FilterByType(serialized, query.TypeFilter);
+                    serialized = filtered ?? new SerializedMember { name = serialized.name, typeName = serialized.typeName };
+                }
+            }
+
+            return serialized;
+        }
+
+        /// <summary>
+        /// Searches the object graph for all fields and properties whose name matches the given
+        /// .NET regex pattern (case-insensitive) and returns them as a flat list of path+value pairs.
+        ///
+        /// Similar to the grep command: a plain string matches exactly, "orbit.*" matches all names
+        /// beginning with "orbit". maxDepth limits how many levels deep the search recurses
+        /// (null = unlimited).
+        ///
+        /// Errors are accumulated in the optional Logs object; nothing is thrown.
+        /// </summary>
+        public IReadOnlyList<ViewMatch> Grep(
+            object? obj,
+            string namePattern,
+            int? maxDepth = null,
+            Type? fallbackObjType = null,
+            int depth = 0,
+            Logs? logs = null,
+            BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+            ILogger? logger = null)
+        {
+            var matches = new List<ViewMatch>();
+            var visited = new HashSet<int>();
+            GrepWalk(obj, obj?.GetType() ?? fallbackObjType, namePattern, maxDepth, 0,
+                     string.Empty, matches, visited, depth, logs, flags, logger);
+            return matches.AsReadOnly();
+        }
+
+        // ─── Grep walker ──────────────────────────────────────────────────────────────
+
+        private void GrepWalk(
+            object? obj,
+            Type? objType,
+            string namePattern,
+            int? maxDepth,
+            int currentDepth,
+            string currentPath,
+            List<ViewMatch> matches,
+            HashSet<int> visited,
+            int depth,
+            Logs? logs,
+            BindingFlags flags,
+            ILogger? logger)
+        {
+            if (obj == null) return;
+            if (maxDepth.HasValue && currentDepth > maxDepth.Value) return;
+
+            var resolvedType = obj.GetType() ?? objType;
+            if (resolvedType == null) return;
+
+            // Circular-reference guard for reference types
+            if (!resolvedType.IsValueType)
+            {
+                var id = RuntimeHelpers.GetHashCode(obj);
+                if (!visited.Add(id)) return;
+            }
+
+            // Arrays / IList — recurse into elements (name-match does not apply to index paths)
+            if (obj is IList list)
+            {
+                var elementType = TypeUtils.GetEnumerableItemType(resolvedType);
+                for (int i = 0; i < list.Count; i++)
+                {
+                    var elemPath = currentPath.Length == 0 ? $"[{i}]" : $"{currentPath}/[{i}]";
+                    GrepWalk(list[i], elementType, namePattern, maxDepth, currentDepth + 1,
+                             elemPath, matches, visited, depth, logs, flags, logger);
+                }
+                return; // arrays also implement IEnumerable — skip field/dict scanning
+            }
+
+            // Fields
+            var fields = GetSerializableFields(resolvedType, flags, logger);
+            if (fields != null)
+            {
+                foreach (var field in fields)
+                {
+                    var fieldPath = currentPath.Length == 0 ? field.Name : $"{currentPath}/{field.Name}";
+
+                    object? fieldValue;
+                    try { fieldValue = field.GetValue(obj); }
+                    catch { continue; }
+
+                    if (Regex.IsMatch(field.Name, namePattern, RegexOptions.IgnoreCase))
+                    {
+                        var serialized = Serialize(fieldValue, field.FieldType, name: field.Name,
+                                                   depth: depth, logs: logs, flags: flags, logger: logger);
+                        matches.Add(new ViewMatch(fieldPath, serialized));
+                    }
+
+                    // Recurse into non-primitive, non-list types
+                    if (!TypeUtils.IsPrimitive(field.FieldType) && !(fieldValue is IList))
+                        GrepWalk(fieldValue, field.FieldType, namePattern, maxDepth, currentDepth + 1,
+                                 fieldPath, matches, visited, depth, logs, flags, logger);
+                    else if (fieldValue is IList)
+                        GrepWalk(fieldValue, field.FieldType, namePattern, maxDepth, currentDepth + 1,
+                                 fieldPath, matches, visited, depth, logs, flags, logger);
+                }
+            }
+
+            // Properties
+            var props = GetSerializableProperties(resolvedType, flags, logger);
+            if (props != null)
+            {
+                foreach (var prop in props)
+                {
+                    if (!prop.CanRead) continue;
+
+                    var propPath = currentPath.Length == 0 ? prop.Name : $"{currentPath}/{prop.Name}";
+
+                    object? propValue;
+                    try { propValue = prop.GetValue(obj); }
+                    catch { continue; }
+
+                    if (Regex.IsMatch(prop.Name, namePattern, RegexOptions.IgnoreCase))
+                    {
+                        var serialized = Serialize(propValue, prop.PropertyType, name: prop.Name,
+                                                   depth: depth, logs: logs, flags: flags, logger: logger);
+                        matches.Add(new ViewMatch(propPath, serialized));
+                    }
+
+                    // Recurse into non-primitive types
+                    if (!TypeUtils.IsPrimitive(prop.PropertyType))
+                        GrepWalk(propValue, prop.PropertyType, namePattern, maxDepth, currentDepth + 1,
+                                 propPath, matches, visited, depth, logs, flags, logger);
+                }
+            }
+
+            // Dictionaries — recurse into values (name-match does not apply to key paths)
+            if (TypeUtils.IsDictionary(resolvedType))
+            {
+                var args    = TypeUtils.GetDictionaryGenericArguments(resolvedType);
+                var valType = args?[1] ?? typeof(object);
+                var dict    = (IDictionary)obj;
+                foreach (var key in dict.Keys)
+                {
+                    var valuePath = currentPath.Length == 0 ? $"[{key}]" : $"{currentPath}/[{key}]";
+                    GrepWalk(dict[key], valType, namePattern, maxDepth, currentDepth + 1,
+                             valuePath, matches, visited, depth, logs, flags, logger);
+                }
+            }
+        }
+
+        // ─── Filter helpers ───────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Returns a shallow copy of <paramref name="m"/> with all fields/props beyond
+        /// <paramref name="maxRelativeDepth"/> levels stripped.
+        /// maxRelativeDepth = 0 keeps the node itself (typeName + value) but removes all children.
+        /// </summary>
+        private static SerializedMember PruneToDepth(SerializedMember m, int maxRelativeDepth)
+        {
+            if (maxRelativeDepth <= 0)
+                return new SerializedMember { name = m.name, typeName = m.typeName, valueJsonElement = m.valueJsonElement };
+
+            var result = new SerializedMember { name = m.name, typeName = m.typeName, valueJsonElement = m.valueJsonElement };
+
+            if (m.fields != null)
+            {
+                result.fields = new SerializedMemberList(m.fields.Count);
+                foreach (var f in m.fields)
+                    result.fields.Add(PruneToDepth(f, maxRelativeDepth - 1));
+            }
+
+            if (m.props != null)
+            {
+                result.props = new SerializedMemberList(m.props.Count);
+                foreach (var p in m.props)
+                    result.props.Add(PruneToDepth(p, maxRelativeDepth - 1));
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Keeps only branches containing at least one field/property whose name matches
+        /// <paramref name="pattern"/> (regex, case-insensitive).
+        /// Returns null when nothing in this subtree matches.
+        /// </summary>
+        private static SerializedMember? FilterByNamePattern(SerializedMember m, string pattern)
+        {
+            var selfMatch      = m.name != null && Regex.IsMatch(m.name, pattern, RegexOptions.IgnoreCase);
+            var filteredFields = FilterListByNamePattern(m.fields, pattern);
+            var filteredProps  = FilterListByNamePattern(m.props,  pattern);
+
+            if (!selfMatch && filteredFields == null && filteredProps == null)
+                return null;
+
+            return new SerializedMember
+            {
+                name             = m.name,
+                typeName         = m.typeName,
+                valueJsonElement = m.valueJsonElement,
+                fields           = selfMatch ? m.fields : filteredFields,
+                props            = selfMatch ? m.props  : filteredProps,
+            };
+        }
+
+        private static SerializedMemberList? FilterListByNamePattern(SerializedMemberList? list, string pattern)
+        {
+            if (list == null || list.Count == 0) return null;
+
+            SerializedMemberList? result = null;
+            foreach (var m in list)
+            {
+                var filtered = FilterByNamePattern(m, pattern);
+                if (filtered != null)
+                {
+                    result ??= new SerializedMemberList();
+                    result.Add(filtered);
+                }
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Keeps only branches where the resolved typeName is assignable to <paramref name="typeFilter"/>.
+        /// Returns null when nothing in this subtree matches.
+        /// </summary>
+        private static SerializedMember? FilterByType(SerializedMember m, Type typeFilter)
+        {
+            var memberType = TypeUtils.GetType(m.typeName);
+            var typeMatch  = memberType != null && typeFilter.IsAssignableFrom(memberType);
+
+            var filteredFields = FilterListByType(m.fields, typeFilter);
+            var filteredProps  = FilterListByType(m.props,  typeFilter);
+
+            if (!typeMatch && filteredFields == null && filteredProps == null)
+                return null;
+
+            return new SerializedMember
+            {
+                name             = m.name,
+                typeName         = m.typeName,
+                valueJsonElement = m.valueJsonElement,
+                fields           = typeMatch ? m.fields : filteredFields,
+                props            = typeMatch ? m.props  : filteredProps,
+            };
+        }
+
+        private static SerializedMemberList? FilterListByType(SerializedMemberList? list, Type typeFilter)
+        {
+            if (list == null || list.Count == 0) return null;
+
+            SerializedMemberList? result = null;
+            foreach (var m in list)
+            {
+                var filtered = FilterByType(m, typeFilter);
+                if (filtered != null)
+                {
+                    result ??= new SerializedMemberList();
+                    result.Add(filtered);
+                }
+            }
+            return result;
+        }
+    }
+}

--- a/ReflectorNet/src/Reflector/Reflector.View.cs
+++ b/ReflectorNet/src/Reflector/Reflector.View.cs
@@ -9,7 +9,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using com.IvanMurzak.ReflectorNet.Model;
 using com.IvanMurzak.ReflectorNet.Utils;
@@ -102,7 +101,7 @@ namespace com.IvanMurzak.ReflectorNet
             ILogger? logger = null)
         {
             var matches = new List<ViewMatch>();
-            var visited = new HashSet<int>();
+            var visited = new HashSet<object>(ObjectReferenceEqualityComparer.Instance);
             GrepWalk(obj, obj?.GetType() ?? fallbackObjType, namePattern, maxDepth, 0,
                      string.Empty, matches, visited, depth, logs, flags, logger);
             return matches.AsReadOnly();
@@ -118,7 +117,7 @@ namespace com.IvanMurzak.ReflectorNet
             int currentDepth,
             string currentPath,
             List<ViewMatch> matches,
-            HashSet<int> visited,
+            HashSet<object> visited,
             int depth,
             Logs? logs,
             BindingFlags flags,
@@ -133,8 +132,7 @@ namespace com.IvanMurzak.ReflectorNet
             // Circular-reference guard for reference types
             if (!resolvedType.IsValueType)
             {
-                var id = RuntimeHelpers.GetHashCode(obj);
-                if (!visited.Add(id)) return;
+                if (!visited.Add(obj)) return;
             }
 
             // Arrays / IList — recurse into elements (name-match does not apply to index paths)
@@ -169,11 +167,8 @@ namespace com.IvanMurzak.ReflectorNet
                         matches.Add(new ViewMatch(fieldPath, serialized));
                     }
 
-                    // Recurse into non-primitive, non-list types
-                    if (!TypeUtils.IsPrimitive(field.FieldType) && !(fieldValue is IList))
-                        GrepWalk(fieldValue, field.FieldType, namePattern, maxDepth, currentDepth + 1,
-                                 fieldPath, matches, visited, depth, logs, flags, logger);
-                    else if (fieldValue is IList)
+                    // Recurse into non-primitive types (IList is handled by GrepWalk's own guard at entry)
+                    if (!TypeUtils.IsPrimitive(field.FieldType))
                         GrepWalk(fieldValue, field.FieldType, namePattern, maxDepth, currentDepth + 1,
                                  fieldPath, matches, visited, depth, logs, flags, logger);
                 }
@@ -334,6 +329,18 @@ namespace com.IvanMurzak.ReflectorNet
                 }
             }
             return result;
+        }
+
+        // Comparer that uses object identity (ReferenceEquals) rather than value equality.
+        // Avoids false-positive cycle-detection when two distinct objects share the same GetHashCode().
+        // netstandard2.1 does not provide System.Collections.Generic.ReferenceEqualityComparer,
+        // so we supply our own.
+        private sealed class ObjectReferenceEqualityComparer : IEqualityComparer<object>
+        {
+            public static readonly ObjectReferenceEqualityComparer Instance = new ObjectReferenceEqualityComparer();
+            private ObjectReferenceEqualityComparer() { }
+            public new bool Equals(object? x, object? y) => ReferenceEquals(x, y);
+            public int GetHashCode(object obj) => System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(obj);
         }
     }
 }

--- a/docs/plan/atomic-modify.md
+++ b/docs/plan/atomic-modify.md
@@ -1,0 +1,427 @@
+# Plan: Atomic Path-Based Modification API
+
+## Context
+
+ReflectorNet's `TryModify` requires supplying the full nested `SerializedMember` graph down to the target. For arrays there is an additional hard limitation: `TryModifyField` calls `TypeMemberUtils.GetField(arrayType, "[2]")` which always returns null. Targeting a single element in an array currently requires replacing the entire array.
+
+**Goal**: add an ergonomic, truly atomic modification API that navigates directly to a specific field, array element, or dictionary entry and modifies only that — without constructing full intermediate objects.
+
+```csharp
+// Modify only the name field on the existing User at index 2 (no new User created)
+reflector.TryModifyAt(ref database, "users/[2]/name", "Bob");
+
+// Partial update of a complex object — only listed fields are touched
+var patch = new SerializedMember { typeName = typeof(User).GetTypeId() };
+patch.SetFieldValue(reflector, "name", "Bob");
+reflector.TryModifyAt(ref database, "users/[2]", patch);
+
+// JSON patch — modify multiple fields at different depths at once
+reflector.TryPatch(ref database, """
+{
+  "admin": { "name": "Carol" },
+  "users": { "[2]": { "name": "Bob", "email": "bob@example.com" } },
+  "config": { "[maxRetries]": 5 }
+}
+""");
+
+// Type replacement — replace StringData field with derived StringDataAdvanced
+var advanced = SerializedMember.FromValue(reflector, typeof(StringDataAdvanced), instance);
+reflector.TryModifyAt(ref database, "admin/displayName", advanced);
+```
+
+---
+
+## Path Format
+
+| Segment form | Meaning |
+|---|---|
+| `fieldName` or `PropertyName` | Field or property by name (plain, no brackets) |
+| `[i]` where inner value is integer AND obj is Array/IList | Array index |
+| `[key]` where obj is `IDictionary<string, T>` | Dictionary string key |
+| `[key]` where obj is `IDictionary<int, T>` | Dictionary integer key |
+
+**Disambiguation**: if the segment starts with `[…]`, check runtime type of `obj`:
+
+- `Array` / `IList<T>` → integer index (inner must parse as int)
+- `IDictionary<K, V>` → key (parse inner to K via `Convert.ChangeType`)
+- Neither → log detailed error and return false
+
+Leading `#/` stripped automatically (compatible with `SerializationContext` path format).
+
+---
+
+## Error Messages
+
+Every navigation failure must include the segment name explicitly:
+
+```
+Segment 'admin' not found on type 'Database'.
+Available fields: admin, users, config
+Available properties: Id, Name
+```
+
+```
+Bracket segment '[99]' index out of range on type 'User[]'. Array length is 3.
+```
+
+```
+Bracket segment '[badKey]' cannot be used as index on type 'User[]'. Expected integer index.
+```
+
+```
+Bracket segment '[myKey]' cannot be used as key on type 'Database'.
+Type is not an array, list, or dictionary.
+```
+
+Errors are accumulated in the `Logs` object (same pattern as `TryModify`) — not thrown as exceptions.
+
+---
+
+## Implementation
+
+### 1. `Reflector.ModifyAt.cs` — new partial file
+
+**Location**: `ReflectorNet/src/Reflector/Reflector.ModifyAt.cs`
+
+#### Public API
+
+```csharp
+// Primary overload — full control via SerializedMember
+public bool TryModifyAt(
+    ref object? obj, string path, SerializedMember value,
+    Type? fallbackObjType = null, int depth = 0, Logs? logs = null,
+    BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+    ILogger? logger = null)
+
+// Convenience generic overload — ideal for leaf/primitive targets
+public bool TryModifyAt<T>(
+    ref object? obj, string path, T value,
+    Type? fallbackObjType = null, int depth = 0, Logs? logs = null,
+    BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+    ILogger? logger = null)
+// body: SerializedMember.FromValue<T>(this, value) → call primary overload
+```
+
+#### Path parsing helpers (private static)
+
+```csharp
+private static string[] ParsePath(string path)
+// Strip "#/" prefix. Split on '/'. Use string.Split(new char[]{'/'}, RemoveEmptyEntries)
+// for netstandard2.1 compatibility.
+
+private static bool TryParseBracketSegment(string segment, out string innerKey)
+// Returns true if segment is "[anything]"; innerKey = content between brackets.
+```
+
+#### Core algorithm — `TryModifyAt` (primary)
+
+```
+1. segments = ParsePath(path)
+2. If empty → terminal: return TryModify(ref obj, value, fallbackObjType, ...)
+3. segment = segments[0]; remainingPath = join(segments[1..], "/")
+4. If TryParseBracketSegment(segment, out innerKey):
+       → TryModifyAtBracketed(ref obj, segment, innerKey, remainingPath, value, ...)
+   Else:
+       → TryModifyAtMember(ref obj, segment, remainingPath, value, ...)
+```
+
+#### `TryModifyAtBracketed` (private)
+
+Dispatches on runtime type of `obj`:
+
+```
+if obj is null:
+    logs.Error("Cannot navigate segment '...' on null object.", depth)
+    return false
+
+if obj is Array or IList<T>:
+    if !int.TryParse(innerKey, out int idx):
+        logs.Error("Bracket segment '[innerKey]' cannot be used as index on type '...'.
+                    Expected integer index.", depth)
+        return false
+    → TryModifyAtArrayIndex(ref obj, segment, idx, remainingPath, value, ...)
+
+elif TypeUtils.IsDictionary(objType):
+    args = TypeUtils.GetDictionaryGenericArguments(objType)
+    keyType = args[0]
+    try: dictKey = Convert.ChangeType(innerKey, keyType)
+    catch: logs.Error("Bracket segment '[innerKey]' cannot be converted to
+                       key type '...' on type '...'.", depth); return false
+    → TryModifyAtDictKey(ref obj, segment, dictKey, remainingPath, value, ...)
+
+else:
+    logs.Error("Bracket segment '[innerKey]' cannot be used on type '...'.
+                Type is not an array, list, or dictionary.", depth)
+    return false
+```
+
+#### `TryModifyAtArrayIndex` (private)
+
+```
+1. if idx < 0 or idx >= length:
+       logs.Error("Bracket segment '[i]' index out of range on type '...'.
+                   Array length is N.", depth)
+       return false
+2. elementType = TypeUtils.GetEnumerableItemType(objType)
+3. currentElement = array.GetValue(idx) or list[idx]
+4. Type-replacement check (see below, only if remainingPath is empty)
+5. success = TryModifyAt(ref currentElement, remainingPath, value, elementType, depth+1, ...)
+6. if success: array.SetValue(currentElement, idx) or list[idx] = currentElement
+7. return success
+```
+
+#### `TryModifyAtDictKey` (private)
+
+```
+1. dict = (IDictionary)obj
+2. currentElement = dict.Contains(dictKey) ? dict[dictKey] : null
+3. valueType = GetDictionaryGenericArguments(objType)[1]
+4. Type-replacement check (see below, only if remainingPath is empty)
+5. success = TryModifyAt(ref currentElement, remainingPath, value, valueType, depth+1, ...)
+6. if success: dict[dictKey] = currentElement
+7. return success
+```
+
+#### `TryModifyAtMember` (private)
+
+```
+1. Try TypeMemberUtils.GetField(objType, flags, memberName):
+       if not found → go to step 2
+       currentValue = fieldInfo.GetValue(obj)
+       Type-replacement check (see below, only if remainingPath is empty)
+       success = TryModifyAt(ref currentValue, remainingPath, value, fieldInfo.FieldType, depth+1, ...)
+       if success: fieldInfo.SetValue(obj, currentValue)   // struct-safe (mirrors BaseReflectionConverter.Modify.cs:342)
+       return success
+
+2. Try TypeMemberUtils.GetProperty(objType, flags, memberName):
+       if not found → go to step 3
+       check CanWrite; if not: logs.Error("Property '...' is read-only.", depth); return false
+       currentValue = propInfo.GetValue(obj)
+       Type-replacement check (see below, only if remainingPath is empty)
+       success = TryModifyAt(ref currentValue, remainingPath, value, propInfo.PropertyType, depth+1, ...)
+       if success: propInfo.SetValue(obj, currentValue)
+       return success
+
+3. // Neither field nor property found
+   (fieldNames, propNames) = GetCachedSerializableMemberNames(reflector, objType, flags, logger)
+   logs.Error(
+     "Segment 'memberName' not found on type 'objType'.\n"
+     + "Available fields: field1, field2, ...\n"
+     + "Available properties: prop1, prop2, ...", depth)
+   return false
+```
+
+#### Type-replacement check (applied in array/dict/member helpers)
+
+Only at **terminal step** (`string.IsNullOrEmpty(remainingPath)`):
+
+```csharp
+if (string.IsNullOrEmpty(remainingPath))
+{
+    var desiredType = TypeUtils.GetTypeWithNamePriority(value, declaredType, out _);
+    if (desiredType != null
+        && currentValue != null
+        && desiredType != currentValue.GetType()
+        && declaredType.IsAssignableFrom(desiredType))
+    {
+        currentValue = null; // force fresh instance creation via TryModify's null branch
+    }
+}
+```
+
+---
+
+### 2. `Reflector.Patch.cs` — new partial file (JSON patch)
+
+**Location**: `ReflectorNet/src/Reflector/Reflector.Patch.cs`
+
+Modifies multiple fields at different depths in a single call using a JSON document as the patch descriptor. Follows **JSON Merge Patch** semantics (RFC 7396) extended with bracket-notation keys for array/dictionary access.
+
+#### Public API
+
+```csharp
+// JsonElement overload (primary)
+public bool TryPatch(
+    ref object? obj, JsonElement patch,
+    Type? fallbackObjType = null, int depth = 0, Logs? logs = null,
+    BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+    ILogger? logger = null)
+
+// String convenience overload (parses JSON internally)
+public bool TryPatch(
+    ref object? obj, string json,
+    Type? fallbackObjType = null, int depth = 0, Logs? logs = null,
+    BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+    ILogger? logger = null)
+// body: parse json → JsonDocument → call JsonElement overload
+```
+
+#### Patch document format
+
+- **JSON object** → navigate: each key is a path segment (field name, `[i]`, `[key]`).
+- **JSON primitive / array** → set value: deserialize and assign to current node.
+- **`"$type"` key** inside a JSON object → optional type hint for type replacement. Value is the full type name string (same as `SerializedMember.typeName`).
+
+Example:
+
+```json
+{
+  "admin": {
+    "$type": "com.MyApp.AdminUser",
+    "name": "Carol",
+    "level": 3
+  },
+  "users": {
+    "[2]": {
+      "email": "bob@example.com"
+    }
+  },
+  "config": {
+    "[maxRetries]": 5,
+    "[timeout]": 30
+  }
+}
+```
+
+#### Core algorithm — `TryPatchInternal` (recursive, private)
+
+```
+TryPatchInternal(ref obj, patch JsonElement, objType, depth, logs, flags, logger):
+
+  1. If patch.ValueKind == Null:
+       obj = null; return true
+
+  2. If patch.ValueKind != Object (primitive, bool, array):
+       // Leaf value — set directly using existing TryModify
+       var member = SerializedMember.FromJson(objType ?? obj?.GetType(), patch)
+       return TryModify(ref obj, member, objType, depth, logs, flags, logger)
+
+  3. // patch is a JSON object — navigate its keys
+     Extract optional "$type" from patch properties
+     Apply type-replacement check using $type (same logic as TryModifyAt)
+
+     var overallSuccess = true
+     foreach property in patch.EnumerateObject():
+       if property.Name == "$type": continue  // already consumed above
+
+       if TryParseBracketSegment(property.Name, out innerKey):
+         success = TryPatchBracketed(ref obj, property.Name, innerKey, property.Value, ...)
+       else:
+         success = TryPatchMember(ref obj, property.Name, property.Value, ...)
+
+       overallSuccess &= success
+
+     return overallSuccess
+```
+
+**`TryPatchMember`** and **`TryPatchBracketed`**: same navigation logic as `TryModifyAtMember` / `TryModifyAtBracketed`, but the "value" is a `JsonElement` subtree rather than a `SerializedMember`. At each level, call `TryPatchInternal` recursively.
+
+Error messages follow the same pattern as `TryModifyAt` (segment name always explicit).
+
+---
+
+### 3. `ArrayReflectionConverter.Modify.cs` — new partial file
+
+**Location**: `ReflectorNet/src/Converter/Reflection/ArrayReflectionConverter.Modify.cs`
+
+Overrides `TryModify` so the existing API (without a path string) also supports partial array element modification when `data.fields` contains `[i]`-named entries.
+
+**Algorithm**:
+
+```
+override TryModify(...):
+  1. If data.valueJsonElement is present → base.TryModify (full replacement, unchanged)
+  2. Partition data.fields into: indexedFields (IsArrayIndexName) and non-indexed
+  3. If no indexedFields → base.TryModify (unchanged)
+  4. Validate obj is non-null; elementType = TypeUtils.GetEnumerableItemType(type)
+  5. For each indexedField:
+       idx = ParseArrayIndex(indexedField.name); bounds check with explicit error
+       currentElement = array[idx]
+       reflector.TryModify(ref currentElement, indexedField, elementType, depth+1, ...)
+       if success: array[idx] = currentElement
+  6. Return AND of all results
+```
+
+Private helpers:
+
+```csharp
+private static bool IsArrayIndexName(string? name)  // "[digits]" only
+private static int ParseArrayIndex(string name)
+```
+
+---
+
+### 4. Tests — `AtomicModifyTests.cs`
+
+**Location**: `ReflectorNet.Tests/src/ReflectorTests/AtomicModifyTests.cs`
+
+Uses `SolarSystem` / `SolarSystem.CelestialBody` / `GameObjectRef`.
+
+| Test | Method | Path / JSON |
+|---|---|---|
+| `TryModifyAt_RootField` | `TryModifyAt<float>` | `"globalOrbitSpeedMultiplier"` |
+| `TryModifyAt_TwoLevelField` | `TryModifyAt<int>` | `"sun/instanceID"` |
+| `TryModifyAt_ArrayElementField` | `TryModifyAt<float>` | `"celestialBodies/[0]/orbitRadius"` → only `[0]` changes |
+| `TryModifyAt_InvalidMember_DetailedError` | `TryModifyAt<float>` | `"doesNotExist"` → false, Logs has "Segment 'doesNotExist' not found" |
+| `TryModifyAt_OutOfBoundsIndex_DetailedError` | `TryModifyAt<float>` | `"celestialBodies/[99]/orbitRadius"` → false, Logs has "'[99]' index out of range" |
+| `TryModifyAt_DictionaryStringKey` | `TryModifyAt<int>` | `"config/[timeout]"` on `Dictionary<string,int>` |
+| `TryModifyAt_DictionaryIntKey` | `TryModifyAt<string>` | `"lookup/[3]"` on `Dictionary<int,string>` |
+| `TryModifyAt_TypeReplacement` | `TryModifyAt(SerializedMember)` | replace base type field with derived |
+| `TryModifyAt_PartialPatch` | `TryModifyAt(SerializedMember)` | navigate to `[0]` and apply partial fields |
+| `TryPatch_MultipleFieldsAtOnce` | `TryPatch(string json)` | JSON with two nested modifications at once |
+| `TryPatch_ArrayElementAndField` | `TryPatch(JsonElement)` | `"[2]"` key navigates into array element |
+| `TryPatch_WithTypeHint` | `TryPatch(string json)` | `"$type"` key triggers type replacement |
+| `ArrayConverter_PartialElementModify` | `TryModify(SerializedMember)` | `[1]`-named field entry → only that element changes |
+
+---
+
+## Files Created (no existing files modified)
+
+| File | Purpose |
+|---|---|
+| `ReflectorNet/src/Reflector/Reflector.ModifyAt.cs` | Path-based single-target modification |
+| `ReflectorNet/src/Reflector/Reflector.Patch.cs` | JSON patch document — multi-path modification |
+| `ReflectorNet/src/Converter/Reflection/ArrayReflectionConverter.Modify.cs` | Partial array element modification via `TryModify` |
+| `ReflectorNet.Tests/src/ReflectorTests/AtomicModifyTests.cs` | Tests for all new functionality |
+
+---
+
+## Key Reused Utilities
+
+| Utility | File | Used for |
+|---|---|---|
+| `TypeMemberUtils.GetField / GetProperty` | `src/Utils/TypeMemberUtils.cs` | member lookup |
+| `TypeUtils.GetEnumerableItemType(type)` | `src/Utils/TypeUtils.Collections.cs` | array element type |
+| `TypeUtils.IsDictionary(type)` | `src/Utils/TypeUtils.Collections.cs` | dictionary detection |
+| `TypeUtils.GetDictionaryGenericArguments(type)` | `src/Utils/TypeUtils.Collections.cs` | key/value types |
+| `TypeUtils.GetTypeWithNamePriority(data, fallback, out _)` | `src/Utils/TypeUtils.GetType.cs` | type replacement / `$type` resolution |
+| `declaredType.IsAssignableFrom(desiredType)` | `src/Utils/TypeUtils.Helpers.cs` | assignability check |
+| `StringUtils.GetPadding(depth)` | `src/Utils/StringUtils.cs` | log indentation |
+| `SerializedMember.FromValue<T>(reflector, value)` | `src/Model/SerializedMember.Static.cs` | generic overload factory |
+| `SerializedMember.FromJson(type, jsonElement)` | `src/Model/SerializedMember.Static.cs` | JSON-to-member for `TryPatch` leaves |
+| `GetCachedSerializableMemberNames(...)` | `BaseReflectionConverter.Modify.cs` | "Available fields/props" in error messages |
+| `IsGenericList(type, out elementType)` | `ArrayReflectionConverter.cs` | reused in override |
+
+---
+
+## Design Notes
+
+**"Truly atomic"**: `TryModifyAt(ref db, "users/[2]/name", "Bob")` navigates directly to the `name` field on the existing `User` at index 2. No new User is created, no other field on the User changes, and no other element in the array is touched.
+
+**`TryPatch` for multi-field**: when multiple fields at different depths need to change in a single operation, use `TryPatch` with a JSON document. The JSON keys drive navigation, leaf values are set directly.
+
+**Type info in `TryPatch`**: the `"$type"` key inside any JSON object node specifies the desired type (full type name). When the desired type is a subtype of the declared type, the existing instance is discarded and a new one is created — enabling polymorphic replacement in JSON form.
+
+**`Logs` throughout**: every public method takes `Logs? logs` and accumulates errors using the same depth-aware pattern as `TryModify`. Errors include explicit segment names. Nothing is thrown.
+
+**No changes to existing files**: all new functionality is additive through new partial-class files and a new test file.
+
+---
+
+## Verification
+
+```bash
+dotnet build --configuration Release
+dotnet test --configuration Release --filter "FullyQualifiedName~AtomicModifyTests"
+dotnet test --configuration Release --verbosity normal
+```


### PR DESCRIPTION
This pull request introduces several major enhancements to ReflectorNet, focusing on atomic, path-based modification and advanced read-side navigation of object graphs. The README is significantly expanded to document these new features, and the core implementation is updated to support partial in-place updates of array/list elements and filtered views of complex objects. These changes make it much easier to precisely modify or inspect deeply nested data structures without affecting unrelated fields.

**New Features and Enhancements:**

*Atomic Path-Based Modification & JSON Patch:*
- Added support for atomic, path-based modification of fields, array/list elements, and dictionary entries using a unified path syntax (e.g., `celestialBodies/[0]/orbitRadius`). Also introduced JSON Patch functionality, allowing multiple fields at different depths to be modified in a single call, following JSON Merge Patch semantics. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R24-R26) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L82-R318)

*Partial In-Place Array/List Element Modification:*
- Implemented partial in-place modification for arrays and lists in `ArrayReflectionConverter`. Now, individual elements can be updated by path without replacing the entire collection, supporting both arrays and `IList` types.

*View & Grep (Read-Side Navigation):*
- Introduced `ViewQuery` and `ViewMatch` classes, enabling filtered serialization and live object graph "grep" functionality. Users can now navigate to subtrees, filter by name regex or type, and extract only the data they need. [[1]](diffhunk://#diff-6d02cd20d005e453bfae68ab53cd481d0c42f64721cfa51db741d690d45e15a9R1-R105) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L82-R318)

*Improved Base Converter Logic:*
- Updated the base reflection converter logic to better distinguish between full replacements and partial updates, ensuring that `SetValue` is only called when appropriate. This prevents overwriting objects when only a subset of fields is being modified.

*Documentation:*
- Expanded the README to thoroughly explain the new features, including usage examples, path syntax, JSON Patch rules, and the new view/grep capabilities. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R24-R26) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L82-R318) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L113-R349)

These improvements provide a much more flexible and robust API for both modifying and inspecting complex object graphs in .NET.