### PR TITLE
Use NuGet trusted publishing (OIDC) instead of API key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,6 +151,9 @@ jobs:
     needs: [build-and-test, check-version-tag]
     runs-on: ubuntu-latest
     if: needs.check-version-tag.outputs.is_new_version == 'true'
+    permissions:
+      id-token: write   # Required for NuGet trusted publishing (OIDC)
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Setup .NET
@@ -169,5 +172,8 @@ jobs:
       - name: Pack
         run: dotnet pack ReflectorNet/ReflectorNet.csproj --no-build --configuration Release --output ./packages
 
+      - name: NuGet login (Trusted Publishing)
+        uses: nuget/login@v1
+
       - name: Publish to NuGet
-        run: dotnet nuget push ./packages/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+        run: dotnet nuget push ./packages/*.nupkg --source https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
## Summary
This PR updates the release workflow to use NuGet's trusted publishing feature with OpenID Connect (OIDC) authentication instead of relying on a static API key stored as a secret.

## Key Changes
- Added required permissions for OIDC token generation (`id-token: write` and `contents: read`)
- Integrated NuGet login step using the official `nuget/login@v1` action for OIDC-based authentication
- Removed dependency on `NUGET_API_KEY` secret from the publish command
- Simplified the NuGet push command by removing the `--api-key` parameter

## Benefits
- **Enhanced Security**: Eliminates the need to manage long-lived API keys as secrets
- **Improved Auditability**: OIDC provides better tracking of who/what published packages
- **Reduced Attack Surface**: Temporary credentials are generated per-workflow run instead of using static secrets
- **Industry Standard**: Aligns with GitHub's recommended security practices for package publishing

https://claude.ai/code/session_01YJxiyTtL8zDVfF86XuGaZS