### PR TITLE
feat: add Enum const to JsonSchema

### DIFF
--- a/ReflectorNet/src/Utils/Json/JsonSchema.Consts.cs
+++ b/ReflectorNet/src/Utils/Json/JsonSchema.Consts.cs
@@ -27,6 +27,7 @@ namespace com.IvanMurzak.ReflectorNet.Utils
         public const string Integer = "integer"; // int, long
         public const string Number = "number"; // float, double, supports int as well
         public const string Boolean = "boolean";
+        public const string Enum = "enum";
         public const string Minimum = "minimum";
         public const string Maximum = "maximum";
 

--- a/ReflectorNet/src/Utils/Json/JsonSchema.Internal.cs
+++ b/ReflectorNet/src/Utils/Json/JsonSchema.Internal.cs
@@ -291,7 +291,7 @@ namespace com.IvanMurzak.ReflectorNet.Utils
             if (underlyingType.IsEnum)
             {
                 var enumValues = new JsonArray();
-                foreach (var enumValue in Enum.GetValues(underlyingType))
+                foreach (var enumValue in System.Enum.GetValues(underlyingType))
                 {
                     enumValues.Add(JsonValue.Create(enumValue.ToString()));
                 }


### PR DESCRIPTION
## Summary
- Add `Enum` constant (`"enum"`) to `JsonSchema.Consts` for consistent JSON Schema property name references
- Disambiguate `System.Enum.GetValues` call in `JsonSchema.Internal` to avoid conflict with the new `Enum` const field

## Test plan
- [x] Verify build passes (`dotnet build --configuration Release`)
- [x] Verify existing tests pass (`dotnet test --configuration Release`)
- [x] Confirm enum schema generation still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)