### PR TITLE
fix: add ArgumentNullException guards to BaseReflectionConverter

### DIFF
--- a/ReflectorNet/src/Converter/Reflection/Base/BaseReflectionConverter.DefaultValue.cs
+++ b/ReflectorNet/src/Converter/Reflection/Base/BaseReflectionConverter.DefaultValue.cs
@@ -43,8 +43,8 @@ namespace com.IvanMurzak.ReflectorNet.Converter
         /// <exception cref="ArgumentException">Thrown when type cannot be instantiated due to constructor limitations.</exception>
         public virtual object? CreateInstance(Reflector reflector, Type type)
         {
-            if (type == null)
-                throw new ArgumentNullException(nameof(type));
+            if (reflector == null) throw new ArgumentNullException(nameof(reflector));
+            if (type == null) throw new ArgumentNullException(nameof(type));
 
             // Handle enums
             if (type.IsEnum)
@@ -155,6 +155,9 @@ namespace com.IvanMurzak.ReflectorNet.Converter
         /// <returns>An appropriate default value for the specified type.</returns>
         public virtual object? GetDefaultValue(Reflector reflector, Type type)
         {
+            if (reflector == null) throw new ArgumentNullException(nameof(reflector));
+            if (type == null) throw new ArgumentNullException(nameof(type));
+
             // Handle nullable types first
             if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>))
                 return null;

--- a/ReflectorNet/src/Converter/Reflection/Base/BaseReflectionConverter.Deserialize.cs
+++ b/ReflectorNet/src/Converter/Reflection/Base/BaseReflectionConverter.Deserialize.cs
@@ -59,6 +59,9 @@ namespace com.IvanMurzak.ReflectorNet.Converter
             ILogger? logger = null,
             DeserializationContext? context = null)
         {
+            if (reflector == null) throw new ArgumentNullException(nameof(reflector));
+            if (data == null) throw new ArgumentNullException(nameof(data));
+
             if (!TryDeserializeValue(
                 reflector,
                 data: data,
@@ -216,6 +219,8 @@ namespace com.IvanMurzak.ReflectorNet.Converter
             Logs? logs = null,
             ILogger? logger = null)
         {
+            if (reflector == null) throw new ArgumentNullException(nameof(reflector));
+
             if (data == null)
             {
                 result = null;
@@ -270,6 +275,10 @@ namespace com.IvanMurzak.ReflectorNet.Converter
             Logs? logs = null,
             ILogger? logger = null)
         {
+            if (reflector == null) throw new ArgumentNullException(nameof(reflector));
+            if (data == null) throw new ArgumentNullException(nameof(data));
+            if (type == null) throw new ArgumentNullException(nameof(type));
+
             var padding = StringUtils.GetPadding(depth);
 
             if (AllowCascadeSerialization)
@@ -361,6 +370,10 @@ namespace com.IvanMurzak.ReflectorNet.Converter
             Logs? logs = null,
             ILogger? logger = null)
         {
+            if (reflector == null) throw new ArgumentNullException(nameof(reflector));
+            if (data == null) throw new ArgumentNullException(nameof(data));
+            if (type == null) throw new ArgumentNullException(nameof(type));
+
             return reflector.JsonSerializer.Deserialize(
                 reflector,
                 data.valueJsonElement,

--- a/ReflectorNet/src/Converter/Reflection/Base/BaseReflectionConverter.Modify.cs
+++ b/ReflectorNet/src/Converter/Reflection/Base/BaseReflectionConverter.Modify.cs
@@ -57,6 +57,10 @@ namespace com.IvanMurzak.ReflectorNet.Converter
             BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
             ILogger? logger = null)
         {
+            if (reflector == null) throw new ArgumentNullException(nameof(reflector));
+            if (data == null) throw new ArgumentNullException(nameof(data));
+            if (type == null) throw new ArgumentNullException(nameof(type));
+
             var padding = StringUtils.GetPadding(depth);
 
             if (obj == null)
@@ -256,6 +260,11 @@ namespace com.IvanMurzak.ReflectorNet.Converter
             BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
             ILogger? logger = null)
         {
+            if (reflector == null) throw new ArgumentNullException(nameof(reflector));
+            if (obj == null) throw new ArgumentNullException(nameof(obj));
+            if (objType == null) throw new ArgumentNullException(nameof(objType));
+            if (fieldValue == null) throw new ArgumentNullException(nameof(fieldValue));
+
             var padding = StringUtils.GetPadding(depth);
 
             if (string.IsNullOrEmpty(fieldValue.name))
@@ -371,6 +380,11 @@ namespace com.IvanMurzak.ReflectorNet.Converter
             BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
             ILogger? logger = null)
         {
+            if (reflector == null) throw new ArgumentNullException(nameof(reflector));
+            if (obj == null) throw new ArgumentNullException(nameof(obj));
+            if (objType == null) throw new ArgumentNullException(nameof(objType));
+            if (propertyValue == null) throw new ArgumentNullException(nameof(propertyValue));
+
             var padding = StringUtils.GetPadding(depth);
 
             if (string.IsNullOrEmpty(propertyValue.name))

--- a/ReflectorNet/src/Converter/Reflection/Base/BaseReflectionConverter.Serialize.cs
+++ b/ReflectorNet/src/Converter/Reflection/Base/BaseReflectionConverter.Serialize.cs
@@ -32,6 +32,8 @@ namespace com.IvanMurzak.ReflectorNet.Converter
             ILogger? logger = null,
             SerializationContext? context = null)
         {
+            if (reflector == null) throw new ArgumentNullException(nameof(reflector));
+
             var actualType = fallbackType ?? obj?.GetType() ?? typeof(T);
 
             return InternalSerialize(
@@ -56,6 +58,9 @@ namespace com.IvanMurzak.ReflectorNet.Converter
             ILogger? logger = null,
             SerializationContext? context = null)
         {
+            if (reflector == null) throw new ArgumentNullException(nameof(reflector));
+            if (obj == null) throw new ArgumentNullException(nameof(obj));
+
             var serializedFields = default(SerializedMemberList);
             var objType = obj.GetType();
 
@@ -116,6 +121,9 @@ namespace com.IvanMurzak.ReflectorNet.Converter
             ILogger? logger = null,
             SerializationContext? context = null)
         {
+            if (reflector == null) throw new ArgumentNullException(nameof(reflector));
+            if (obj == null) throw new ArgumentNullException(nameof(obj));
+
             var serializedProperties = default(SerializedMemberList);
             var objType = obj.GetType();
 

--- a/ReflectorNet/src/Reflector/Reflector.Modify.cs
+++ b/ReflectorNet/src/Reflector/Reflector.Modify.cs
@@ -43,6 +43,9 @@ namespace com.IvanMurzak.ReflectorNet
             BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
             ILogger? logger = null)
         {
+            if (data == null)
+                throw new ArgumentNullException(nameof(data));
+
             var padding = StringUtils.GetPadding(depth);
 
             if (obj == null && data.IsNull())


### PR DESCRIPTION
## Summary
- Replace uninformative `NullReferenceException` with explicit `ArgumentNullException(nameof(...))` across all `BaseReflectionConverter<T>` entry points
- Guards added to 12 methods across 4 partial files: `TryModify`, `TryModifyField`, `TryModifyProperty`, `Serialize`, `SerializeFields`, `SerializeProperties`, `Deserialize`, `TryDeserializeValue`, `TryDeserializeValueInternal`, `DeserializeValueAsJsonElement`, `CreateInstance`, `GetDefaultValue`
- Parameters guarded: `reflector`, `data`/`fieldValue`/`propertyValue`, `type`/`objType`, `obj` (where non-nullable)

## Context
Intermittent `NullReferenceException: Object reference not set to an instance of an object` in `TryModify` with certain data models gave no indication of which parameter was null. Now the exception message explicitly names the null argument.

## Test plan
- [x] `dotnet build --configuration Release` — passes
- [x] `dotnet test --configuration Release` — all 1355 tests pass
- [x] Verify improved exception messages appear when null arguments are passed at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)