### PR TITLE
fix: System.Text.Json v8 compatibility for Unity 6.5

### DIFF
--- a/ReflectorNet.Tests.OuterAssembly/ReflectorNet.Tests.OuterAssembly.csproj
+++ b/ReflectorNet.Tests.OuterAssembly/ReflectorNet.Tests.OuterAssembly.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="10.0.3" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ReflectorNet.Tests/ReflectorNet.Tests.csproj
+++ b/ReflectorNet.Tests/ReflectorNet.Tests.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="System.Text.Json" Version="10.0.3" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>

--- a/ReflectorNet/ReflectorNet.csproj
+++ b/ReflectorNet/ReflectorNet.csproj
@@ -9,7 +9,7 @@
 
     <!-- NuGet Package Information -->
     <PackageId>com.IvanMurzak.ReflectorNet</PackageId>
-    <Version>4.1.0</Version>
+    <Version>4.2.0</Version>
     <Authors>Ivan Murzak</Authors>
     <Copyright>Copyright © Ivan Murzak 2025</Copyright>
     <Description>ReflectorNet is an advanced .NET reflection toolkit designed for AI-driven scenarios. Effortlessly search for C# methods using natural language queries, invoke any method by supplying arguments as JSON, and receive results as JSON. The library also provides a powerful API to inspect, modify, and manage in-memory object instances dynamically via JSON data. Ideal for automation, testing, and AI integration workflows.</Description>
@@ -26,7 +26,14 @@
     <None Include="..\LICENSE" Pack="true" PackagePath="\" />
   </ItemGroup>
 
-  <ItemGroup>
+  <!-- v8 for netstandard2.1 and net8.0 (Unity + general compatibility) -->
+  <ItemGroup Condition="'$(TargetFramework)' != 'net9.0'">
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+  </ItemGroup>
+
+  <!-- v10 for net9.0 (full features including System.Text.Json.Schema) -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.3" />
     <PackageReference Include="System.Text.Json" Version="10.0.3" />
   </ItemGroup>

--- a/ReflectorNet/ReflectorNet.csproj
+++ b/ReflectorNet/ReflectorNet.csproj
@@ -9,7 +9,7 @@
 
     <!-- NuGet Package Information -->
     <PackageId>com.IvanMurzak.ReflectorNet</PackageId>
-    <Version>4.2.0</Version>
+    <Version>5.0.0</Version>
     <Authors>Ivan Murzak</Authors>
     <Copyright>Copyright © Ivan Murzak 2025</Copyright>
     <Description>ReflectorNet is an advanced .NET reflection toolkit designed for AI-driven scenarios. Effortlessly search for C# methods using natural language queries, invoke any method by supplying arguments as JSON, and receive results as JSON. The library also provides a powerful API to inspect, modify, and manage in-memory object instances dynamically via JSON data. Ideal for automation, testing, and AI integration workflows.</Description>

--- a/ReflectorNet/ReflectorNet.csproj
+++ b/ReflectorNet/ReflectorNet.csproj
@@ -26,16 +26,9 @@
     <None Include="..\LICENSE" Pack="true" PackagePath="\" />
   </ItemGroup>
 
-  <!-- v8 for netstandard2.1 and net8.0 (Unity + general compatibility) -->
-  <ItemGroup Condition="'$(TargetFramework)' != 'net9.0'">
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-  </ItemGroup>
-
-  <!-- v10 for net9.0 (full features including System.Text.Json.Schema) -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.3" />
-    <PackageReference Include="System.Text.Json" Version="10.0.3" />
   </ItemGroup>
 
 </Project>

--- a/ReflectorNet/src/Utils/Json/JsonSchema.cs
+++ b/ReflectorNet/src/Utils/Json/JsonSchema.cs
@@ -45,7 +45,6 @@ namespace com.IvanMurzak.ReflectorNet.Utils
     /// </summary>
     public partial class JsonSchema
     {
-
         /// <summary>
         /// Generates a comprehensive JSON Schema representation for the specified generic type.
         /// This method provides flexible schema generation supporting both full schema definitions

--- a/ReflectorNet/src/Utils/Json/JsonSchema.cs
+++ b/ReflectorNet/src/Utils/Json/JsonSchema.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text.Json.Nodes;
+
 using System.Threading.Tasks;
 using com.IvanMurzak.ReflectorNet.Json;
 

--- a/ReflectorNet/src/Utils/Json/JsonSchema.cs
+++ b/ReflectorNet/src/Utils/Json/JsonSchema.cs
@@ -10,7 +10,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text.Json.Nodes;
+#if NET9_0_OR_GREATER
 using System.Text.Json.Schema;
+#endif
 using System.Threading.Tasks;
 using com.IvanMurzak.ReflectorNet.Json;
 
@@ -45,10 +47,12 @@ namespace com.IvanMurzak.ReflectorNet.Utils
     /// </summary>
     public partial class JsonSchema
     {
+#if NET9_0_OR_GREATER
         readonly JsonSchemaExporterOptions jsonSchemaExporterOptions = new JsonSchemaExporterOptions
         {
             TreatNullObliviousAsNonNullable = false
         };
+#endif
 
         /// <summary>
         /// Generates a comprehensive JSON Schema representation for the specified generic type.

--- a/ReflectorNet/src/Utils/Json/JsonSchema.cs
+++ b/ReflectorNet/src/Utils/Json/JsonSchema.cs
@@ -10,9 +10,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text.Json.Nodes;
-#if NET9_0_OR_GREATER
-using System.Text.Json.Schema;
-#endif
 using System.Threading.Tasks;
 using com.IvanMurzak.ReflectorNet.Json;
 
@@ -47,12 +44,6 @@ namespace com.IvanMurzak.ReflectorNet.Utils
     /// </summary>
     public partial class JsonSchema
     {
-#if NET9_0_OR_GREATER
-        readonly JsonSchemaExporterOptions jsonSchemaExporterOptions = new JsonSchemaExporterOptions
-        {
-            TreatNullObliviousAsNonNullable = false
-        };
-#endif
 
         /// <summary>
         /// Generates a comprehensive JSON Schema representation for the specified generic type.

--- a/ReflectorNet/src/Utils/TypeUtils.Description.cs
+++ b/ReflectorNet/src/Utils/TypeUtils.Description.cs
@@ -3,7 +3,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 
-#if NETSTANDARD2_1_OR_GREATER || NET8_0_OR_GREATER
+#if NET9_0_OR_GREATER
 using System.Text.Json.Schema;
 #endif
 
@@ -114,7 +114,7 @@ namespace com.IvanMurzak.ReflectorNet.Utils
             return propertyInfo != null ? GetPropertyDescription(propertyInfo) : null;
         }
 
-#if NETSTANDARD2_1_OR_GREATER || NET8_0_OR_GREATER
+#if NET9_0_OR_GREATER
         /// <summary>
         /// Retrieves the description of a property from a <see cref="JsonSchemaExporterContext"/>.
         /// </summary>

--- a/ReflectorNet/src/Utils/TypeUtils.Description.cs
+++ b/ReflectorNet/src/Utils/TypeUtils.Description.cs
@@ -3,10 +3,6 @@ using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 
-#if NET9_0_OR_GREATER
-using System.Text.Json.Schema;
-#endif
-
 namespace com.IvanMurzak.ReflectorNet.Utils
 {
     public static partial class TypeUtils
@@ -113,47 +109,6 @@ namespace com.IvanMurzak.ReflectorNet.Utils
             var propertyInfo = type.GetProperty(propertyName);
             return propertyInfo != null ? GetPropertyDescription(propertyInfo) : null;
         }
-
-#if NET9_0_OR_GREATER
-        /// <summary>
-        /// Retrieves the description of a property from a <see cref="JsonSchemaExporterContext"/>.
-        /// </summary>
-        /// <param name="context">The JSON schema exporter context.</param>
-        /// <returns>The description of the property associated with the context; otherwise, <see langword="null"/>.</returns>
-        public static string? GetPropertyDescription(JsonSchemaExporterContext context)
-        {
-            if (context.PropertyInfo == null || context.PropertyInfo.DeclaringType == null)
-                return null;
-
-            var memberInfo = context.PropertyInfo.DeclaringType
-                .GetMember(
-                    name: context.PropertyInfo.Name,
-                    bindingAttr: BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
-                .FirstOrDefault();
-
-            if (memberInfo == null)
-            {
-                var pascalCaseName = ToPascalCase(context.PropertyInfo.Name);
-                memberInfo = context.PropertyInfo.DeclaringType
-                    .GetMember(
-                        name: pascalCaseName,
-                        bindingAttr: BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
-                    .FirstOrDefault();
-            }
-
-            if (memberInfo == null)
-            {
-                var allMembers = context.PropertyInfo.DeclaringType.GetMembers(BindingFlags.Public | BindingFlags.Instance);
-                memberInfo = allMembers.FirstOrDefault(m =>
-                    string.Equals(m.Name, context.PropertyInfo.Name, StringComparison.OrdinalIgnoreCase));
-            }
-
-            if (memberInfo == null)
-                return null;
-
-            return GetDescription(memberInfo);
-        }
-#endif
 
         private static string ToPascalCase(string camelCase)
         {

--- a/ReflectorNet/src/Utils/TypeUtils.Description.cs
+++ b/ReflectorNet/src/Utils/TypeUtils.Description.cs
@@ -1,6 +1,5 @@
 using System;
 using System.ComponentModel;
-using System.Linq;
 using System.Reflection;
 
 namespace com.IvanMurzak.ReflectorNet.Utils


### PR DESCRIPTION
## Summary
- Compile `netstandard2.1` and `net8.0` targets against System.Text.Json v8.0.5 (Unity 6.5 ships v8 as built-in BCL)
- Keep `net9.0` on System.Text.Json v10.0.3 (full features including `System.Text.Json.Schema`)
- Guard dead v9+-only code (`JsonSchemaExporterOptions`, `JsonSchemaExporterContext`) behind `#if NET9_0_OR_GREATER`
- Bump version to 4.2.0

## Context
Unity 6.5 introduces System.Text.Json v8 as a built-in BCL assembly. Our DLLs referenced v10, causing CS1705 compile errors. This change ensures the netstandard2.1 DLL (consumed by Unity) works with any STJ v8+ version.

Fixes IvanMurzak/Unity-MCP#625

## Test plan
- [x] `dotnet build --configuration Release` — all 3 TFMs (netstandard2.1, net8.0, net9.0) build successfully
- [x] `dotnet test --configuration Release` — all 1355 tests pass on net8.0 and net9.0
- [x] netstandard2.1 DLL references STJ v8.0.5 (verified via deps.json)
- [x] Verify in Unity 6.5 project — no CS1705 errors