### PR TITLE
feat: re-encode JSON Schema type IDs with firewall-safe delimiters

### DIFF
--- a/ReflectorNet.Tests/src/SchemaTests/TestGetTypeDecodeSchemaRef.cs
+++ b/ReflectorNet.Tests/src/SchemaTests/TestGetTypeDecodeSchemaRef.cs
@@ -7,69 +7,117 @@ namespace com.IvanMurzak.ReflectorNet.Tests.SchemaTests
 {
     /// <summary>
     /// TypeUtils.GetType(...) is the funnel for every type-name → Type resolution invoked by
-    /// reflector modify / field-set / property-set actions. Callers may submit a raw type id
-    /// (e.g. <c>System.Int32[]</c>) or a $ref-style percent-encoded form (e.g. <c>System.Int32%5B%5D</c>).
-    /// Both must resolve to the same Type. Only these five chars are decoded:
-    /// <c>%2B → +</c>, <c>%3C → &lt;</c>, <c>%3E → &gt;</c>, <c>%5B → [</c>, <c>%5D → ]</c>.
+    /// reflector modify / field-set / property-set actions. Callers may submit a C#-canonical raw
+    /// type id (e.g. <c>System.Int32[]</c>, <c>IList&lt;Int32&gt;</c>, <c>Outer+Nested</c>) or the
+    /// firewall-safe schema form (issue #80) that a JSON Schema <c>$ref</c> consumer round-trips
+    /// (e.g. <c>System.Int32-1</c>, <c>IList(Int32)</c>, <c>Outer-Nested</c>). Both must resolve to
+    /// the same Type. The safe-form conversion is:
+    /// <c>( → &lt;</c>, <c>) → &gt;</c>, <c>-&lt;digits&gt; → array rank</c>, <c>-&lt;ident&gt; → +</c> (nested class).
     /// </summary>
     public class TestGetTypeDecodeSchemaRef : BaseTest
     {
         public TestGetTypeDecodeSchemaRef(ITestOutputHelper output) : base(output) { }
 
         [Theory]
-        [InlineData("System.Int32[]", "System.Int32%5B%5D")]
-        [InlineData("System.String[]", "System.String%5B%5D")]
-        [InlineData("System.Int32[][]", "System.Int32%5B%5D%5B%5D")]
-        public void GetType_Array_AcceptsBothRawAndEncodedBrackets(string raw, string encoded)
+        [InlineData("System.Int32[]", "System.Int32-1")]
+        [InlineData("System.String[]", "System.String-1")]
+        [InlineData("System.Int32[][]", "System.Int32-1-1")]
+        public void GetType_Array_AcceptsBothRawAndSafeForm(string raw, string safe)
         {
             var rawType = TypeUtils.GetType(raw);
-            var encodedType = TypeUtils.GetType(encoded);
+            var safeType = TypeUtils.GetType(safe);
 
             Assert.NotNull(rawType);
-            Assert.Same(rawType, encodedType);
+            Assert.Same(rawType, safeType);
+        }
+
+        [Fact]
+        public void GetType_MultiDimensionalArray_SafeRankResolves()
+        {
+            // rank-2 safe form '-2' must resolve to int[,] (distinct from jagged int[][] / '-1-1').
+            var safe = TypeUtils.GetType("System.Int32-2");
+            Assert.NotNull(safe);
+            Assert.Equal(typeof(int[,]), safe);
+
+            var jagged = TypeUtils.GetType("System.Int32-1-1");
+            Assert.NotNull(jagged);
+            Assert.Equal(typeof(int[][]), jagged);
+
+            Assert.NotEqual(safe, jagged);
         }
 
         [Theory]
         [InlineData(
             "System.Collections.Generic.IList<System.Int32>",
-            "System.Collections.Generic.IList%3CSystem.Int32%3E")]
+            "System.Collections.Generic.IList(System.Int32)")]
         [InlineData(
             "System.Collections.Generic.IEnumerable<System.String>",
-            "System.Collections.Generic.IEnumerable%3CSystem.String%3E")]
-        public void GetType_Generic_AcceptsBothRawAndEncodedAngleBrackets(string raw, string encoded)
+            "System.Collections.Generic.IEnumerable(System.String)")]
+        public void GetType_Generic_AcceptsBothRawAndSafeForm(string raw, string safe)
         {
             var rawType = TypeUtils.GetType(raw);
-            var encodedType = TypeUtils.GetType(encoded);
+            var safeType = TypeUtils.GetType(safe);
 
             Assert.NotNull(rawType);
-            Assert.Same(rawType, encodedType);
+            Assert.Same(rawType, safeType);
         }
 
         [Fact]
-        public void GetType_NestedClass_AcceptsBothRawAndEncodedPlus()
+        public void GetType_NestedClass_AcceptsBothRawAndSafeForm()
         {
             var raw = "com.IvanMurzak.ReflectorNet.OuterAssembly.Model.ParentClass+NestedClass";
-            var encoded = "com.IvanMurzak.ReflectorNet.OuterAssembly.Model.ParentClass%2BNestedClass";
+            var safe = "com.IvanMurzak.ReflectorNet.OuterAssembly.Model.ParentClass-NestedClass";
 
             var rawType = TypeUtils.GetType(raw);
-            var encodedType = TypeUtils.GetType(encoded);
+            var safeType = TypeUtils.GetType(safe);
 
             Assert.NotNull(rawType);
             Assert.Equal(typeof(ParentClass.NestedClass), rawType);
-            Assert.Same(rawType, encodedType);
+            Assert.Same(rawType, safeType);
         }
 
         [Fact]
-        public void GetType_GenericOfArrayOfNestedClass_AcceptsFullyEncodedForm()
+        public void GetType_GenericOfArrayOfNestedClass_AcceptsSafeForm()
         {
-            // The $ref-style encoded form a JSON Schema consumer would send through.
-            var encoded = "System.Collections.Generic.IList%3Ccom.IvanMurzak.ReflectorNet.OuterAssembly.Model.ParentClass%2BNestedClass%5B%5D%3E";
+            // The combo from issue #80: IList<Outer+Nested[]>. Both the raw id and the safe-form
+            // (what GetSchemaTypeId now emits, and what a $ref consumer round-trips) resolve to it.
+            var raw = "System.Collections.Generic.IList<com.IvanMurzak.ReflectorNet.OuterAssembly.Model.ParentClass+NestedClass[]>";
+            var safe = "System.Collections.Generic.IList(com.IvanMurzak.ReflectorNet.OuterAssembly.Model.ParentClass-NestedClass-1)";
 
-            var encodedType = TypeUtils.GetType(encoded);
+            var rawType = TypeUtils.GetType(raw);
+            var safeType = TypeUtils.GetType(safe);
             var directType = typeof(IList<ParentClass.NestedClass[]>);
 
-            Assert.NotNull(encodedType);
-            Assert.Equal(directType, encodedType);
+            Assert.NotNull(rawType);
+            Assert.Equal(directType, rawType);
+            Assert.NotNull(safeType);
+            Assert.Equal(directType, safeType);
+        }
+
+        [Fact]
+        public void GetType_SafeFormRoundTripsFromGetSchemaTypeId()
+        {
+            // End-to-end: GetSchemaTypeId emits the safe form; GetType resolves it back to the
+            // original Type. This is the round-trip the JSON Schema $defs/$ref pipeline relies on.
+            var types = new[]
+            {
+                typeof(int[]),
+                typeof(int[][]),
+                typeof(int[,]),
+                typeof(IList<int>),
+                typeof(IEnumerable<string>),
+                typeof(ParentClass.NestedClass),
+                typeof(ParentClass.NestedClass[]),
+                typeof(IList<ParentClass.NestedClass[]>),
+            };
+
+            foreach (var type in types)
+            {
+                var id = type.GetSchemaTypeId();
+                var resolved = TypeUtils.GetType(id);
+                Assert.Equal(type, resolved);
+                _output.WriteLine($"{type} -> {id} -> {resolved}");
+            }
         }
     }
 }

--- a/ReflectorNet.Tests/src/SchemaTests/TestSchemaRefEncoding.cs
+++ b/ReflectorNet.Tests/src/SchemaTests/TestSchemaRefEncoding.cs
@@ -7,16 +7,28 @@ using Xunit.Abstractions;
 namespace com.IvanMurzak.ReflectorNet.Tests.SchemaTests
 {
     /// <summary>
-    /// $defs keys are stored as raw type-ids (arbitrary JSON object keys).
-    /// $ref values are URI references and must percent-encode chars not allowed in URI fragments.
-    /// A consumer that URI-decodes the $ref fragment recovers the raw type-id and looks it up in $defs.
+    /// Firewall-safe schema type-ids (issue #80): the type-id uses delimiters that are illegal in
+    /// C# identifiers, legal unescaped in a URI fragment, and absent from every LLM provider's
+    /// content-firewall blocklist. As a result NO escaping is needed: the $defs key (raw JSON
+    /// object key) and the $ref value (URI reference) are byte-identical, and NEITHER contains any
+    /// of the forbidden chars '&lt; &gt; [ ] + %' (the first five were the old structural chars, '%'
+    /// was the percent-encoding from the superseded PR #77 that broke Google Gemini).
     /// </summary>
     public class TestSchemaRefEncoding : BaseTest
     {
         public TestSchemaRefEncoding(ITestOutputHelper output) : base(output) { }
 
+        static readonly char[] ForbiddenChars = new[] { '<', '>', '[', ']', '+', '%' };
+
+        static void AssertNoForbiddenChars(string value, string what)
+        {
+            foreach (var c in ForbiddenChars)
+                Assert.False(value.Contains(c),
+                    $"{what} '{value}' must not contain forbidden char '{c}'.");
+        }
+
         [Fact]
-        public void GetSchemaRef_GenericType_EncodesAngleBrackets()
+        public void GetSchemaRef_GenericType_RefHasNoForbiddenChars()
         {
             var reflector = new Reflector();
             var schema = reflector.GetSchemaRef<IList<TestType>>();
@@ -24,53 +36,58 @@ namespace com.IvanMurzak.ReflectorNet.Tests.SchemaTests
             var refValue = schema?[JsonSchema.Ref]?.ToString();
             Assert.NotNull(refValue);
             Assert.StartsWith(JsonSchema.RefValue, refValue);
-            Assert.Contains("%3C", refValue);
-            Assert.Contains("%3E", refValue);
-            Assert.DoesNotContain("<", refValue);
-            Assert.DoesNotContain(">", refValue);
+
+            // Only check the type-id fragment (the RefValue prefix may legitimately contain '#').
+            var fragment = refValue!.Substring(JsonSchema.RefValue.Length);
+            AssertNoForbiddenChars(fragment, "$ref fragment");
         }
 
         [Fact]
-        public void GetSchemaRef_ArrayType_EncodesBrackets()
+        public void GetSchemaRef_ArrayType_RefHasNoForbiddenChars()
         {
             var reflector = new Reflector();
             var schema = reflector.GetSchemaRef<TestType[]>();
 
             var refValue = schema?[JsonSchema.Ref]?.ToString();
             Assert.NotNull(refValue);
-            Assert.Contains("%5B", refValue);
-            Assert.Contains("%5D", refValue);
-            Assert.DoesNotContain("[", refValue!.Substring(JsonSchema.RefValue.Length));
-            Assert.DoesNotContain("]", refValue.Substring(JsonSchema.RefValue.Length));
+
+            var fragment = refValue!.Substring(JsonSchema.RefValue.Length);
+            AssertNoForbiddenChars(fragment, "$ref fragment");
         }
 
         [Fact]
-        public void GetSchemaRef_NestedClass_EncodesPlus()
+        public void GetSchemaRef_NestedClass_RefHasNoForbiddenChars()
         {
             var reflector = new Reflector();
             var schema = reflector.GetSchemaRef<ParentClass.NestedClass>();
 
             var refValue = schema?[JsonSchema.Ref]?.ToString();
             Assert.NotNull(refValue);
-            Assert.Contains("%2B", refValue);
-            Assert.DoesNotContain("+", refValue);
+
+            var fragment = refValue!.Substring(JsonSchema.RefValue.Length);
+            AssertNoForbiddenChars(fragment, "$ref fragment");
         }
 
         [Fact]
-        public void GetSchema_GenericType_DefsKeyIsRaw()
+        public void GetSchema_GenericType_DefsKeyEqualsRefAndHasNoForbiddenChars()
         {
-            // $defs keys must remain raw — URI-decoding the $ref fragment must recover them verbatim.
+            // $defs key must equal the $ref value (symmetric — no encode/decode asymmetry) and
+            // must itself contain none of the forbidden chars.
             var reflector = new Reflector();
             var schema = reflector.GetSchema<IList<TestType>>();
             var defs = schema?[JsonSchema.Defs] as System.Text.Json.Nodes.JsonObject;
 
             Assert.NotNull(defs);
-            Assert.True(defs!.ContainsKey(typeof(IList<TestType>).GetSchemaTypeId()),
-                $"$defs must contain raw key '{typeof(IList<TestType>).GetSchemaTypeId()}'. Actual keys: {string.Join(", ", defs.Select(kvp => kvp.Key))}");
+            var expectedKey = typeof(IList<TestType>).GetSchemaTypeId();
+            Assert.True(defs!.ContainsKey(expectedKey),
+                $"$defs must contain key '{expectedKey}'. Actual keys: {string.Join(", ", defs.Select(kvp => kvp.Key))}");
+
+            foreach (var key in defs.Select(kvp => kvp.Key))
+                AssertNoForbiddenChars(key, "$defs key");
         }
 
         [Fact]
-        public void GetSchema_NestedClass_DefsKeyIsRawWithPlus()
+        public void GetSchema_NestedClass_DefsKeyHasNoForbiddenChars()
         {
             var reflector = new Reflector();
             var schema = reflector.GetSchema<ParentClass.NestedClass>();
@@ -78,9 +95,31 @@ namespace com.IvanMurzak.ReflectorNet.Tests.SchemaTests
 
             Assert.NotNull(defs);
             var expectedKey = typeof(ParentClass.NestedClass).GetSchemaTypeId();
-            Assert.Contains("+", expectedKey);
+            Assert.DoesNotContain("+", expectedKey);
             Assert.True(defs!.ContainsKey(expectedKey),
-                $"$defs must contain raw key '{expectedKey}'. Actual keys: {string.Join(", ", defs.Select(kvp => kvp.Key))}");
+                $"$defs must contain key '{expectedKey}'. Actual keys: {string.Join(", ", defs.Select(kvp => kvp.Key))}");
+
+            foreach (var key in defs.Select(kvp => kvp.Key))
+                AssertNoForbiddenChars(key, "$defs key");
+        }
+
+        [Fact]
+        public void GetSchema_GenericOfArrayOfNestedClass_DefsKeyEqualsRef()
+        {
+            // The combo from issue #80: IList<Outer+Nested[]>. Verify the $ref value equals the
+            // $defs key for the top-level type (symmetric) and neither has forbidden chars.
+            var reflector = new Reflector();
+            var schema = reflector.GetSchema<IList<ParentClass.NestedClass[]>>();
+            var defs = schema?[JsonSchema.Defs] as System.Text.Json.Nodes.JsonObject;
+
+            Assert.NotNull(defs);
+            foreach (var key in defs!.Select(kvp => kvp.Key))
+                AssertNoForbiddenChars(key, "$defs key");
+
+            // A nested $ref somewhere in the schema points at the array element type's id; assert
+            // every $defs key is a valid no-forbidden-char id and the top-level id is present.
+            var topId = typeof(IList<ParentClass.NestedClass[]>).GetSchemaTypeId();
+            AssertNoForbiddenChars(topId, "top-level type-id");
         }
     }
 }

--- a/ReflectorNet.Tests/src/SchemaTests/TestSchemaTypeId.cs
+++ b/ReflectorNet.Tests/src/SchemaTests/TestSchemaTypeId.cs
@@ -5,12 +5,18 @@ using Xunit.Abstractions;
 
 namespace com.IvanMurzak.ReflectorNet.Tests.SchemaTests
 {
+    /// <summary>
+    /// GetSchemaTypeId emits firewall-safe structural delimiters (issue #80):
+    /// generic '&lt;&gt;' -> '()', nested-class '+' -> '-', array '[]' rank-1 -> '-1',
+    /// rank-N -> '-N', jagged repeats stack (int[][] -> '-1-1'). Namespace '.' and
+    /// generic-arg separator ',' stay literal. The $defs key equals the $ref value (symmetric).
+    /// </summary>
     public class TestSchemaTypeId : BaseTest
     {
         public TestSchemaTypeId(ITestOutputHelper output) : base(output) { }
 
         [Fact]
-        public void GetSchemaTypeId_SimpleArray_ShouldAppendArray()
+        public void GetSchemaTypeId_SimpleArray_ShouldAppendArrayRank()
         {
             // Arrange
             var type = typeof(int[]);
@@ -19,12 +25,12 @@ namespace com.IvanMurzak.ReflectorNet.Tests.SchemaTests
             var result = type.GetSchemaTypeId();
 
             // Assert
-            Assert.Equal("System.Int32[]", result);
+            Assert.Equal("System.Int32-1", result);
             _output.WriteLine($"int[] -> {result}");
         }
 
         [Fact]
-        public void GetSchemaTypeId_NestedArray_ShouldAppendMultipleArrays()
+        public void GetSchemaTypeId_NestedArray_ShouldStackArrayRanks()
         {
             // Arrange
             var type = typeof(int[][]);
@@ -33,12 +39,12 @@ namespace com.IvanMurzak.ReflectorNet.Tests.SchemaTests
             var result = type.GetSchemaTypeId();
 
             // Assert
-            Assert.Equal("System.Int32[][]", result);
+            Assert.Equal("System.Int32-1-1", result);
             _output.WriteLine($"int[][] -> {result}");
         }
 
         [Fact]
-        public void GetSchemaTypeId_TripleNestedArray_ShouldAppendThreeArrays()
+        public void GetSchemaTypeId_TripleNestedArray_ShouldStackThreeArrayRanks()
         {
             // Arrange
             var type = typeof(int[][][]);
@@ -47,8 +53,23 @@ namespace com.IvanMurzak.ReflectorNet.Tests.SchemaTests
             var result = type.GetSchemaTypeId();
 
             // Assert
-            Assert.Equal("System.Int32[][][]", result);
+            Assert.Equal("System.Int32-1-1-1", result);
             _output.WriteLine($"int[][][] -> {result}");
+        }
+
+        [Fact]
+        public void GetSchemaTypeId_MultiDimensionalArray_ShouldUseRankDigit()
+        {
+            // Arrange
+            var type = typeof(int[,]);
+
+            // Act
+            var result = type.GetSchemaTypeId();
+
+            // Assert
+            // rank-2 multi-dimensional array -> '-2' (distinct from jagged int[][] -> '-1-1').
+            Assert.Equal("System.Int32-2", result);
+            _output.WriteLine($"int[,] -> {result}");
         }
 
         [Fact]
@@ -61,7 +82,7 @@ namespace com.IvanMurzak.ReflectorNet.Tests.SchemaTests
             var result = type.GetSchemaTypeId();
 
             // Assert
-            Assert.Equal("System.String[]", result);
+            Assert.Equal("System.String-1", result);
             _output.WriteLine($"string[] -> {result}");
         }
 
@@ -103,7 +124,7 @@ namespace com.IvanMurzak.ReflectorNet.Tests.SchemaTests
             var result = type.GetSchemaTypeId();
 
             // Assert
-            Assert.Equal("System.Int32[]", result);
+            Assert.Equal("System.Int32-1", result);
             _output.WriteLine($"int?[] -> {result}");
         }
 
@@ -117,7 +138,7 @@ namespace com.IvanMurzak.ReflectorNet.Tests.SchemaTests
             var result = type.GetSchemaTypeId();
 
             // Assert
-            Assert.Equal("System.Collections.Generic.IEnumerable<System.Int32>", result);
+            Assert.Equal("System.Collections.Generic.IEnumerable(System.Int32)", result);
             _output.WriteLine($"IEnumerable<int> -> {result}");
         }
 
@@ -131,7 +152,7 @@ namespace com.IvanMurzak.ReflectorNet.Tests.SchemaTests
             var result = type.GetSchemaTypeId();
 
             // Assert
-            Assert.Equal("System.Collections.Generic.ICollection<System.String>", result);
+            Assert.Equal("System.Collections.Generic.ICollection(System.String)", result);
             _output.WriteLine($"ICollection<string> -> {result}");
         }
 
@@ -145,7 +166,7 @@ namespace com.IvanMurzak.ReflectorNet.Tests.SchemaTests
             var result = type.GetSchemaTypeId();
 
             // Assert
-            Assert.Equal("System.Collections.Generic.IList<System.Int32>", result);
+            Assert.Equal("System.Collections.Generic.IList(System.Int32)", result);
             _output.WriteLine($"IList<int> -> {result}");
         }
 
@@ -164,7 +185,7 @@ namespace com.IvanMurzak.ReflectorNet.Tests.SchemaTests
         }
 
         [Fact]
-        public void GetSchemaTypeId_ArrayOfCustomClass_ShouldAppendArray()
+        public void GetSchemaTypeId_ArrayOfCustomClass_ShouldAppendArrayRank()
         {
             // Arrange
             var type = typeof(TestType[]);
@@ -173,12 +194,12 @@ namespace com.IvanMurzak.ReflectorNet.Tests.SchemaTests
             var result = type.GetSchemaTypeId();
 
             // Assert
-            Assert.Equal("com.IvanMurzak.ReflectorNet.Tests.SchemaTests.TestType[]", result);
+            Assert.Equal("com.IvanMurzak.ReflectorNet.Tests.SchemaTests.TestType-1", result);
             _output.WriteLine($"TestType[] -> {result}");
         }
 
         [Fact]
-        public void GetSchemaTypeId_NestedClass_ShouldUsePlusSeparator()
+        public void GetSchemaTypeId_NestedClass_ShouldUseHyphenSeparator()
         {
             // Arrange
             var type = typeof(ParentClass.NestedClass);
@@ -187,14 +208,14 @@ namespace com.IvanMurzak.ReflectorNet.Tests.SchemaTests
             var result = type.GetSchemaTypeId();
 
             // Assert
-            // $defs keys are raw JSON object keys — the '+' nested-class separator is stored
-            // verbatim. URI encoding happens at the $ref site only (see TestSchemaRefEncoding).
-            Assert.Equal("com.IvanMurzak.ReflectorNet.OuterAssembly.Model.ParentClass+NestedClass", result);
+            // Firewall-safe nested-class delimiter (issue #80): '+' -> '-'. The $defs key and the
+            // $ref value are byte-identical (no encode/decode asymmetry).
+            Assert.Equal("com.IvanMurzak.ReflectorNet.OuterAssembly.Model.ParentClass-NestedClass", result);
             _output.WriteLine($"ParentClass.NestedClass -> {result}");
         }
 
         [Fact]
-        public void GetSchemaTypeId_NestedStaticClass_ShouldUsePlusSeparator()
+        public void GetSchemaTypeId_NestedStaticClass_ShouldUseHyphenSeparator()
         {
             // Arrange
             var type = typeof(ParentClass.NestedStaticClass);
@@ -203,12 +224,12 @@ namespace com.IvanMurzak.ReflectorNet.Tests.SchemaTests
             var result = type.GetSchemaTypeId();
 
             // Assert
-            Assert.Equal("com.IvanMurzak.ReflectorNet.OuterAssembly.Model.ParentClass+NestedStaticClass", result);
+            Assert.Equal("com.IvanMurzak.ReflectorNet.OuterAssembly.Model.ParentClass-NestedStaticClass", result);
             _output.WriteLine($"ParentClass.NestedStaticClass -> {result}");
         }
 
         [Fact]
-        public void GetSchemaTypeId_NestedClassInStaticParent_ShouldUsePlusSeparator()
+        public void GetSchemaTypeId_NestedClassInStaticParent_ShouldUseHyphenSeparator()
         {
             // Arrange
             var type = typeof(StaticParentClass.NestedClass);
@@ -217,12 +238,12 @@ namespace com.IvanMurzak.ReflectorNet.Tests.SchemaTests
             var result = type.GetSchemaTypeId();
 
             // Assert
-            Assert.Equal("com.IvanMurzak.ReflectorNet.OuterAssembly.Model.StaticParentClass+NestedClass", result);
+            Assert.Equal("com.IvanMurzak.ReflectorNet.OuterAssembly.Model.StaticParentClass-NestedClass", result);
             _output.WriteLine($"StaticParentClass.NestedClass -> {result}");
         }
 
         [Fact]
-        public void GetSchemaTypeId_ArrayOfNestedClass_ShouldUsePlusAndBrackets()
+        public void GetSchemaTypeId_ArrayOfNestedClass_ShouldUseHyphenAndArrayRank()
         {
             // Arrange
             var type = typeof(ParentClass.NestedClass[]);
@@ -231,8 +252,24 @@ namespace com.IvanMurzak.ReflectorNet.Tests.SchemaTests
             var result = type.GetSchemaTypeId();
 
             // Assert
-            Assert.Equal("com.IvanMurzak.ReflectorNet.OuterAssembly.Model.ParentClass+NestedClass[]", result);
+            Assert.Equal("com.IvanMurzak.ReflectorNet.OuterAssembly.Model.ParentClass-NestedClass-1", result);
             _output.WriteLine($"ParentClass.NestedClass[] -> {result}");
+        }
+
+        [Fact]
+        public void GetSchemaTypeId_GenericOfArrayOfNestedClass_ShouldComposeAllDelimiters()
+        {
+            // Arrange — the combo from issue #80: IList<Outer+Nested[]>.
+            var type = typeof(IList<ParentClass.NestedClass[]>);
+
+            // Act
+            var result = type.GetSchemaTypeId();
+
+            // Assert
+            Assert.Equal(
+                "System.Collections.Generic.IList(com.IvanMurzak.ReflectorNet.OuterAssembly.Model.ParentClass-NestedClass-1)",
+                result);
+            _output.WriteLine($"IList<ParentClass.NestedClass[]> -> {result}");
         }
     }
 }

--- a/ReflectorNet.Tests/src/SchemaTests/TestTypeId.cs
+++ b/ReflectorNet.Tests/src/SchemaTests/TestTypeId.cs
@@ -4,6 +4,12 @@ using Xunit.Abstractions;
 
 namespace com.IvanMurzak.ReflectorNet.Tests.SchemaTests
 {
+    /// <summary>
+    /// GetTypeId emits firewall-safe structural delimiters (issue #80):
+    /// generic '&lt;&gt;' -> '()', nested-class '+' -> '-', array '[]' rank-1 -> '-1',
+    /// rank-N -> '-N', jagged repeats stack (int[][] -> '-1-1'). Namespace '.' and
+    /// generic-arg separator ',' stay literal.
+    /// </summary>
     public class TestTypeId : BaseTest
     {
         public TestTypeId(ITestOutputHelper output) : base(output) { }
@@ -18,7 +24,7 @@ namespace com.IvanMurzak.ReflectorNet.Tests.SchemaTests
             var result = type.GetTypeId();
 
             // Assert
-            Assert.Equal($"System.Int32{TypeUtils.ArraySuffix}", result);
+            Assert.Equal("System.Int32-1", result);
             _output.WriteLine($"int[] -> {result}");
         }
 
@@ -32,7 +38,7 @@ namespace com.IvanMurzak.ReflectorNet.Tests.SchemaTests
             var result = type.GetTypeId();
 
             // Assert
-            Assert.Equal($"System.Int32{TypeUtils.ArraySuffix}{TypeUtils.ArraySuffix}", result);
+            Assert.Equal("System.Int32-1-1", result);
             _output.WriteLine($"int[][] -> {result}");
         }
 
@@ -46,8 +52,23 @@ namespace com.IvanMurzak.ReflectorNet.Tests.SchemaTests
             var result = type.GetTypeId();
 
             // Assert
-            Assert.Equal($"System.Int32{TypeUtils.ArraySuffix}{TypeUtils.ArraySuffix}{TypeUtils.ArraySuffix}", result);
+            Assert.Equal("System.Int32-1-1-1", result);
             _output.WriteLine($"int[][][] -> {result}");
+        }
+
+        [Fact]
+        public void GetTypeId_MultiDimensionalArray_ShouldUseRankDigit()
+        {
+            // Arrange
+            var type = typeof(int[,]);
+
+            // Act
+            var result = type.GetTypeId();
+
+            // Assert
+            // rank-2 multi-dimensional array -> '-2' (distinct from jagged int[][] -> '-1-1').
+            Assert.Equal("System.Int32-2", result);
+            _output.WriteLine($"int[,] -> {result}");
         }
 
         [Fact]
@@ -60,12 +81,12 @@ namespace com.IvanMurzak.ReflectorNet.Tests.SchemaTests
             var result = type.GetTypeId();
 
             // Assert
-            Assert.Equal($"System.String{TypeUtils.ArraySuffix}", result);
+            Assert.Equal("System.String-1", result);
             _output.WriteLine($"string[] -> {result}");
         }
 
         [Fact]
-        public void GetTypeId_ListOfInt_ShouldAppendArray()
+        public void GetTypeId_ListOfInt_ShouldUseParens()
         {
             // Arrange
             var type = typeof(List<int>);
@@ -74,12 +95,12 @@ namespace com.IvanMurzak.ReflectorNet.Tests.SchemaTests
             var result = type.GetTypeId();
 
             // Assert
-            Assert.Equal($"System.Collections.Generic.List<System.Int32>", result);
+            Assert.Equal("System.Collections.Generic.List(System.Int32)", result);
             _output.WriteLine($"List<int> -> {result}");
         }
 
         [Fact]
-        public void GetTypeId_ListOfIntArray_ShouldAppendTwoArrays()
+        public void GetTypeId_ListOfIntArray_ShouldAppendArrayRank()
         {
             // Arrange
             var type = typeof(List<int[]>);
@@ -88,12 +109,12 @@ namespace com.IvanMurzak.ReflectorNet.Tests.SchemaTests
             var result = type.GetTypeId();
 
             // Assert
-            Assert.Equal($"System.Collections.Generic.List<System.Int32{TypeUtils.ArraySuffix}>", result);
+            Assert.Equal("System.Collections.Generic.List(System.Int32-1)", result);
             _output.WriteLine($"List<int[]> -> {result}");
         }
 
         [Fact]
-        public void GetTypeId_ListOfListOfInt_ShouldAppendTwoArrays()
+        public void GetTypeId_ListOfListOfInt_ShouldNestParens()
         {
             // Arrange
             var type = typeof(List<List<int>>);
@@ -102,12 +123,12 @@ namespace com.IvanMurzak.ReflectorNet.Tests.SchemaTests
             var result = type.GetTypeId();
 
             // Assert
-            Assert.Equal("System.Collections.Generic.List<System.Collections.Generic.List<System.Int32>>", result);
+            Assert.Equal("System.Collections.Generic.List(System.Collections.Generic.List(System.Int32))", result);
             _output.WriteLine($"List<List<int>> -> {result}");
         }
 
         [Fact]
-        public void GetTypeId_ListOfDoubleNestedArray_ShouldAppendThreeArrays()
+        public void GetTypeId_ListOfDoubleNestedArray_ShouldStackArrayRanks()
         {
             // Arrange
             var type = typeof(List<int[][]>);
@@ -116,7 +137,7 @@ namespace com.IvanMurzak.ReflectorNet.Tests.SchemaTests
             var result = type.GetTypeId();
 
             // Assert
-            Assert.Equal($"System.Collections.Generic.List<System.Int32{TypeUtils.ArraySuffix}{TypeUtils.ArraySuffix}>", result);
+            Assert.Equal("System.Collections.Generic.List(System.Int32-1-1)", result);
             _output.WriteLine($"List<int[][]> -> {result}");
         }
 
@@ -130,7 +151,7 @@ namespace com.IvanMurzak.ReflectorNet.Tests.SchemaTests
             var result = type.GetTypeId();
 
             // Assert
-            Assert.Equal($"System.Collections.Generic.List<System.String{TypeUtils.ArraySuffix}>", result);
+            Assert.Equal("System.Collections.Generic.List(System.String-1)", result);
             _output.WriteLine($"List<string[]> -> {result}");
         }
 
@@ -144,7 +165,7 @@ namespace com.IvanMurzak.ReflectorNet.Tests.SchemaTests
             var result = type.GetTypeId();
 
             // Assert
-            Assert.Equal($"System.Collections.Generic.List<System.Collections.Generic.List<System.String{TypeUtils.ArraySuffix}>{TypeUtils.ArraySuffix}>", result);
+            Assert.Equal("System.Collections.Generic.List(System.Collections.Generic.List(System.String-1)-1)", result);
             _output.WriteLine($"List<List<string[]>[]> -> {result}");
         }
 
@@ -186,7 +207,7 @@ namespace com.IvanMurzak.ReflectorNet.Tests.SchemaTests
             var result = type.GetTypeId();
 
             // Assert
-            Assert.Equal($"System.Int32{TypeUtils.ArraySuffix}", result);
+            Assert.Equal("System.Int32-1", result);
             _output.WriteLine($"int?[] -> {result}");
         }
 
@@ -203,6 +224,9 @@ namespace com.IvanMurzak.ReflectorNet.Tests.SchemaTests
             Assert.Contains("System.Collections.Generic.Dictionary", result);
             Assert.Contains("System.String", result);
             Assert.Contains("System.Int32", result);
+            // Firewall-safe: no angle brackets in the emitted id.
+            Assert.DoesNotContain("<", result);
+            Assert.DoesNotContain(">", result);
             _output.WriteLine($"Dictionary<string, int> -> {result}");
         }
     }

--- a/ReflectorNet.Tests/src/TypeUtilsTests/GetTypeIdTests.cs
+++ b/ReflectorNet.Tests/src/TypeUtilsTests/GetTypeIdTests.cs
@@ -18,7 +18,10 @@ namespace com.IvanMurzak.ReflectorNet.Tests.TypeUtilsTests
 {
     /// <summary>
     /// Tests for TypeUtils.GetTypeId() method.
-    /// Verifies that types are correctly converted to their string representation.
+    /// Verifies that types are correctly converted to their firewall-safe string representation (issue #80):
+    /// generic '&lt;&gt;' -> '()', nested-class '+' -> '-', array '[]' rank-1 -> '-1', rank-N -> '-N',
+    /// jagged repeats stack (int[][] -> '-1-1', int[,][] -> '-2-1'). Namespace '.' and generic-arg
+    /// separator ',' stay literal.
     /// </summary>
     public class GetTypeIdTests : BaseTest
     {
@@ -73,8 +76,8 @@ namespace com.IvanMurzak.ReflectorNet.Tests.TypeUtilsTests
             ["System.IComparable"] = typeof(IComparable),
             ["System.ICloneable"] = typeof(ICloneable),
 
-            // Nested types
-            ["System.Environment+SpecialFolder"] = typeof(Environment.SpecialFolder),
+            // Nested types (firewall-safe: '+' -> '-')
+            ["System.Environment-SpecialFolder"] = typeof(Environment.SpecialFolder),
         };
 
         #endregion
@@ -82,47 +85,47 @@ namespace com.IvanMurzak.ReflectorNet.Tests.TypeUtilsTests
         #region Test Data - Built-in Array Types
 
         /// <summary>
-        /// Array types derived from built-in types.
+        /// Array types derived from built-in types (firewall-safe: '[]' -> '-rank').
         /// </summary>
         public static readonly Dictionary<string, Type> BuiltInArrayTypes = new Dictionary<string, Type>
         {
-            // Simple arrays
-            ["System.Int32[]"] = typeof(int[]),
-            ["System.String[]"] = typeof(string[]),
-            ["System.Boolean[]"] = typeof(bool[]),
-            ["System.Double[]"] = typeof(double[]),
-            ["System.Object[]"] = typeof(object[]),
-            ["System.Byte[]"] = typeof(byte[]),
-            ["System.DateTime[]"] = typeof(DateTime[]),
-            ["System.Guid[]"] = typeof(Guid[]),
+            // Simple arrays (rank-1 -> '-1')
+            ["System.Int32-1"] = typeof(int[]),
+            ["System.String-1"] = typeof(string[]),
+            ["System.Boolean-1"] = typeof(bool[]),
+            ["System.Double-1"] = typeof(double[]),
+            ["System.Object-1"] = typeof(object[]),
+            ["System.Byte-1"] = typeof(byte[]),
+            ["System.DateTime-1"] = typeof(DateTime[]),
+            ["System.Guid-1"] = typeof(Guid[]),
 
-            // Jagged arrays
-            ["System.Int32[][]"] = typeof(int[][]),
-            ["System.String[][]"] = typeof(string[][]),
-            ["System.Object[][]"] = typeof(object[][]),
+            // Jagged arrays (each rank-1 level stacks: '-1-1')
+            ["System.Int32-1-1"] = typeof(int[][]),
+            ["System.String-1-1"] = typeof(string[][]),
+            ["System.Object-1-1"] = typeof(object[][]),
 
             // Triple jagged arrays
-            ["System.Int32[][][]"] = typeof(int[][][]),
+            ["System.Int32-1-1-1"] = typeof(int[][][]),
 
-            // Multi-dimensional arrays
-            ["System.Int32[,]"] = typeof(int[,]),
-            ["System.String[,]"] = typeof(string[,]),
-            ["System.Object[,]"] = typeof(object[,]),
+            // Multi-dimensional arrays (rank-N -> '-N')
+            ["System.Int32-2"] = typeof(int[,]),
+            ["System.String-2"] = typeof(string[,]),
+            ["System.Object-2"] = typeof(object[,]),
 
             // Multi-dimensional arrays (Rank 3)
-            ["System.Int32[,,]"] = typeof(int[,,]),
-            ["System.Double[,,]"] = typeof(double[,,]),
+            ["System.Int32-3"] = typeof(int[,,]),
+            ["System.Double-3"] = typeof(double[,,]),
 
             // Multi-dimensional arrays (Rank 4)
-            ["System.Int32[,,,]"] = typeof(int[,,,]),
+            ["System.Int32-4"] = typeof(int[,,,]),
 
             // Mixed arrays (Array of 2D arrays)
-            // Note: C# syntax int[][,] is (int[,])[] -> System.Int32[,][]
-            ["System.Int32[,][]"] = typeof(int[][,]),
+            // C# typeof(int[][,]) is (int[,])[] -> element int[,] (rank 2) wrapped in rank-1 array -> '-2-1'
+            ["System.Int32-2-1"] = typeof(int[][,]),
 
             // Mixed arrays (2D array of arrays)
-            // Note: C# syntax int[,][] is (int[])[,] -> System.Int32[][,]
-            ["System.Int32[][,]"] = typeof(int[,][]),
+            // C# typeof(int[,][]) is (int[])[,] -> element int[] (rank 1) wrapped in rank-2 array -> '-1-2'
+            ["System.Int32-1-2"] = typeof(int[,][]),
         };
 
         #endregion
@@ -130,49 +133,49 @@ namespace com.IvanMurzak.ReflectorNet.Tests.TypeUtilsTests
         #region Test Data - Built-in Generic Types
 
         /// <summary>
-        /// Generic types from System.Collections.Generic.
+        /// Generic types from System.Collections.Generic (firewall-safe: '&lt;&gt;' -> '()').
         /// </summary>
         public static readonly Dictionary<string, Type> BuiltInGenericTypes = new Dictionary<string, Type>
         {
             // List<T>
-            ["System.Collections.Generic.List<System.Int32>"] = typeof(List<int>),
-            ["System.Collections.Generic.List<System.String>"] = typeof(List<string>),
-            ["System.Collections.Generic.List<System.Object>"] = typeof(List<object>),
-            ["System.Collections.Generic.List<System.DateTime>"] = typeof(List<DateTime>),
+            ["System.Collections.Generic.List(System.Int32)"] = typeof(List<int>),
+            ["System.Collections.Generic.List(System.String)"] = typeof(List<string>),
+            ["System.Collections.Generic.List(System.Object)"] = typeof(List<object>),
+            ["System.Collections.Generic.List(System.DateTime)"] = typeof(List<DateTime>),
 
             // Dictionary<TKey, TValue>
-            ["System.Collections.Generic.Dictionary<System.String,System.Int32>"] = typeof(Dictionary<string, int>),
-            ["System.Collections.Generic.Dictionary<System.Int32,System.String>"] = typeof(Dictionary<int, string>),
-            ["System.Collections.Generic.Dictionary<System.String,System.Object>"] = typeof(Dictionary<string, object>),
-            ["System.Collections.Generic.Dictionary<System.Guid,System.String>"] = typeof(Dictionary<Guid, string>),
+            ["System.Collections.Generic.Dictionary(System.String,System.Int32)"] = typeof(Dictionary<string, int>),
+            ["System.Collections.Generic.Dictionary(System.Int32,System.String)"] = typeof(Dictionary<int, string>),
+            ["System.Collections.Generic.Dictionary(System.String,System.Object)"] = typeof(Dictionary<string, object>),
+            ["System.Collections.Generic.Dictionary(System.Guid,System.String)"] = typeof(Dictionary<Guid, string>),
 
             // HashSet<T>
-            ["System.Collections.Generic.HashSet<System.Int32>"] = typeof(HashSet<int>),
-            ["System.Collections.Generic.HashSet<System.String>"] = typeof(HashSet<string>),
+            ["System.Collections.Generic.HashSet(System.Int32)"] = typeof(HashSet<int>),
+            ["System.Collections.Generic.HashSet(System.String)"] = typeof(HashSet<string>),
 
             // Queue<T> and Stack<T>
-            ["System.Collections.Generic.Queue<System.Int32>"] = typeof(Queue<int>),
-            ["System.Collections.Generic.Stack<System.String>"] = typeof(Stack<string>),
+            ["System.Collections.Generic.Queue(System.Int32)"] = typeof(Queue<int>),
+            ["System.Collections.Generic.Stack(System.String)"] = typeof(Stack<string>),
 
             // LinkedList<T>
-            ["System.Collections.Generic.LinkedList<System.Double>"] = typeof(LinkedList<double>),
+            ["System.Collections.Generic.LinkedList(System.Double)"] = typeof(LinkedList<double>),
 
             // KeyValuePair<TKey, TValue>
-            ["System.Collections.Generic.KeyValuePair<System.String,System.Int32>"] = typeof(KeyValuePair<string, int>),
+            ["System.Collections.Generic.KeyValuePair(System.String,System.Int32)"] = typeof(KeyValuePair<string, int>),
 
             // Nullable<T> struct (note: Nullable types are unwrapped by GetTypeId)
-            // ["System.Nullable<System.Int32>"] = typeof(Nullable<int>), // This returns "System.Int32"
+            // ["System.Nullable(System.Int32)"] = typeof(Nullable<int>), // This returns "System.Int32"
 
             // Generic interfaces
-            ["System.Collections.Generic.IList<System.Int32>"] = typeof(IList<int>),
-            ["System.Collections.Generic.ICollection<System.String>"] = typeof(ICollection<string>),
-            ["System.Collections.Generic.IEnumerable<System.Object>"] = typeof(IEnumerable<object>),
-            ["System.Collections.Generic.IDictionary<System.String,System.Object>"] = typeof(IDictionary<string, object>),
-            ["System.Collections.Generic.ISet<System.Int32>"] = typeof(ISet<int>),
+            ["System.Collections.Generic.IList(System.Int32)"] = typeof(IList<int>),
+            ["System.Collections.Generic.ICollection(System.String)"] = typeof(ICollection<string>),
+            ["System.Collections.Generic.IEnumerable(System.Object)"] = typeof(IEnumerable<object>),
+            ["System.Collections.Generic.IDictionary(System.String,System.Object)"] = typeof(IDictionary<string, object>),
+            ["System.Collections.Generic.ISet(System.Int32)"] = typeof(ISet<int>),
 
             // Tuple types
-            ["System.Tuple<System.Int32,System.String>"] = typeof(Tuple<int, string>),
-            ["System.Tuple<System.Int32,System.String,System.Boolean>"] = typeof(Tuple<int, string, bool>),
+            ["System.Tuple(System.Int32,System.String)"] = typeof(Tuple<int, string>),
+            ["System.Tuple(System.Int32,System.String,System.Boolean)"] = typeof(Tuple<int, string, bool>),
         };
 
         #endregion
@@ -185,31 +188,31 @@ namespace com.IvanMurzak.ReflectorNet.Tests.TypeUtilsTests
         public static readonly Dictionary<string, Type> NestedGenericTypes = new Dictionary<string, Type>
         {
             // List of arrays
-            ["System.Collections.Generic.List<System.Int32[]>"] = typeof(List<int[]>),
-            ["System.Collections.Generic.List<System.String[]>"] = typeof(List<string[]>),
+            ["System.Collections.Generic.List(System.Int32-1)"] = typeof(List<int[]>),
+            ["System.Collections.Generic.List(System.String-1)"] = typeof(List<string[]>),
 
             // Array of lists
-            ["System.Collections.Generic.List<System.Int32>[]"] = typeof(List<int>[]),
-            ["System.Collections.Generic.List<System.String>[]"] = typeof(List<string>[]),
+            ["System.Collections.Generic.List(System.Int32)-1"] = typeof(List<int>[]),
+            ["System.Collections.Generic.List(System.String)-1"] = typeof(List<string>[]),
 
             // List of lists
-            ["System.Collections.Generic.List<System.Collections.Generic.List<System.Int32>>"] = typeof(List<List<int>>),
-            ["System.Collections.Generic.List<System.Collections.Generic.List<System.String>>"] = typeof(List<List<string>>),
+            ["System.Collections.Generic.List(System.Collections.Generic.List(System.Int32))"] = typeof(List<List<int>>),
+            ["System.Collections.Generic.List(System.Collections.Generic.List(System.String))"] = typeof(List<List<string>>),
 
             // Dictionary with list value
-            ["System.Collections.Generic.Dictionary<System.String,System.Collections.Generic.List<System.Int32>>"] = typeof(Dictionary<string, List<int>>),
+            ["System.Collections.Generic.Dictionary(System.String,System.Collections.Generic.List(System.Int32))"] = typeof(Dictionary<string, List<int>>),
 
             // Dictionary with dictionary value
-            ["System.Collections.Generic.Dictionary<System.String,System.Collections.Generic.Dictionary<System.Int32,System.Boolean>>"] = typeof(Dictionary<string, Dictionary<int, bool>>),
+            ["System.Collections.Generic.Dictionary(System.String,System.Collections.Generic.Dictionary(System.Int32,System.Boolean))"] = typeof(Dictionary<string, Dictionary<int, bool>>),
 
             // List of dictionaries
-            ["System.Collections.Generic.List<System.Collections.Generic.Dictionary<System.String,System.Int32>>"] = typeof(List<Dictionary<string, int>>),
+            ["System.Collections.Generic.List(System.Collections.Generic.Dictionary(System.String,System.Int32))"] = typeof(List<Dictionary<string, int>>),
 
             // Triple nested generics
-            ["System.Collections.Generic.List<System.Collections.Generic.List<System.Collections.Generic.List<System.Int32>>>"] = typeof(List<List<List<int>>>),
+            ["System.Collections.Generic.List(System.Collections.Generic.List(System.Collections.Generic.List(System.Int32)))"] = typeof(List<List<List<int>>>),
 
             // Complex combinations
-            ["System.Collections.Generic.Dictionary<System.String,System.Collections.Generic.List<System.Collections.Generic.Dictionary<System.Int32,System.Boolean>>>"] = typeof(Dictionary<string, List<Dictionary<int, bool>>>),
+            ["System.Collections.Generic.Dictionary(System.String,System.Collections.Generic.List(System.Collections.Generic.Dictionary(System.Int32,System.Boolean)))"] = typeof(Dictionary<string, List<Dictionary<int, bool>>>),
         };
 
         #endregion
@@ -229,16 +232,16 @@ namespace com.IvanMurzak.ReflectorNet.Tests.TypeUtilsTests
             ["com.IvanMurzak.ReflectorNet.Tests.TestClass"] = typeof(TestClass),
 
             // Nested classes
-            ["com.IvanMurzak.ReflectorNet.Tests.Model.SolarSystem+CelestialBody"] = typeof(SolarSystem.CelestialBody),
+            ["com.IvanMurzak.ReflectorNet.Tests.Model.SolarSystem-CelestialBody"] = typeof(SolarSystem.CelestialBody),
 
             // Arrays of custom types
-            ["com.IvanMurzak.ReflectorNet.Tests.Model.Vector3[]"] = typeof(Vector3[]),
-            ["com.IvanMurzak.ReflectorNet.Tests.Model.GameObjectRef[]"] = typeof(GameObjectRef[]),
+            ["com.IvanMurzak.ReflectorNet.Tests.Model.Vector3-1"] = typeof(Vector3[]),
+            ["com.IvanMurzak.ReflectorNet.Tests.Model.GameObjectRef-1"] = typeof(GameObjectRef[]),
 
             // Generic with custom types
-            ["System.Collections.Generic.List<com.IvanMurzak.ReflectorNet.Tests.Model.Vector3>"] = typeof(List<Vector3>),
-            ["System.Collections.Generic.List<com.IvanMurzak.ReflectorNet.Tests.Model.GameObjectRef>"] = typeof(List<GameObjectRef>),
-            ["System.Collections.Generic.Dictionary<System.String,com.IvanMurzak.ReflectorNet.Tests.Model.Vector3>"] = typeof(Dictionary<string, Vector3>),
+            ["System.Collections.Generic.List(com.IvanMurzak.ReflectorNet.Tests.Model.Vector3)"] = typeof(List<Vector3>),
+            ["System.Collections.Generic.List(com.IvanMurzak.ReflectorNet.Tests.Model.GameObjectRef)"] = typeof(List<GameObjectRef>),
+            ["System.Collections.Generic.Dictionary(System.String,com.IvanMurzak.ReflectorNet.Tests.Model.Vector3)"] = typeof(Dictionary<string, Vector3>),
         };
 
         #endregion
@@ -258,11 +261,11 @@ namespace com.IvanMurzak.ReflectorNet.Tests.TypeUtilsTests
             ["com.IvanMurzak.ReflectorNet.Model.MethodData"] = typeof(MethodData),
 
             // Arrays
-            ["com.IvanMurzak.ReflectorNet.Model.SerializedMember[]"] = typeof(SerializedMember[]),
+            ["com.IvanMurzak.ReflectorNet.Model.SerializedMember-1"] = typeof(SerializedMember[]),
 
             // Generics with ReflectorNet types
-            ["System.Collections.Generic.List<com.IvanMurzak.ReflectorNet.Model.SerializedMember>"] = typeof(List<SerializedMember>),
-            ["System.Collections.Generic.Dictionary<System.String,com.IvanMurzak.ReflectorNet.Model.SerializedMember>"] = typeof(Dictionary<string, SerializedMember>),
+            ["System.Collections.Generic.List(com.IvanMurzak.ReflectorNet.Model.SerializedMember)"] = typeof(List<SerializedMember>),
+            ["System.Collections.Generic.Dictionary(System.String,com.IvanMurzak.ReflectorNet.Model.SerializedMember)"] = typeof(Dictionary<string, SerializedMember>),
         };
 
         #endregion
@@ -285,62 +288,62 @@ namespace com.IvanMurzak.ReflectorNet.Tests.TypeUtilsTests
             // ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterGenericClass`1"] = typeof(OuterGenericClass<>),
 
             // Generic types (closed/constructed)
-            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterGenericClass<System.Int32>"] = typeof(OuterGenericClass<int>),
-            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterGenericClass<System.String>"] = typeof(OuterGenericClass<string>),
-            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterGenericClass<System.DateTime>"] = typeof(OuterGenericClass<DateTime>),
+            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterGenericClass(System.Int32)"] = typeof(OuterGenericClass<int>),
+            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterGenericClass(System.String)"] = typeof(OuterGenericClass<string>),
+            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterGenericClass(System.DateTime)"] = typeof(OuterGenericClass<DateTime>),
 
             // Generic with two type parameters
-            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterGenericClass2<System.Int32,System.String>"] = typeof(OuterGenericClass2<int, string>),
-            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterGenericClass2<System.String,System.Boolean>"] = typeof(OuterGenericClass2<string, bool>),
+            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterGenericClass2(System.Int32,System.String)"] = typeof(OuterGenericClass2<int, string>),
+            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterGenericClass2(System.String,System.Boolean)"] = typeof(OuterGenericClass2<string, bool>),
 
             // Generic with three type parameters
-            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterGenericClass3<System.Int32,System.String,System.Boolean>"] = typeof(OuterGenericClass3<int, string, bool>),
+            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterGenericClass3(System.Int32,System.String,System.Boolean)"] = typeof(OuterGenericClass3<int, string, bool>),
 
             // Generic struct
-            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterGenericStruct<System.Int32>"] = typeof(OuterGenericStruct<int>),
-            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterGenericStruct<System.Double>"] = typeof(OuterGenericStruct<double>),
-            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterGenericStruct2<System.Int32,System.String>"] = typeof(OuterGenericStruct2<int, string>),
+            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterGenericStruct(System.Int32)"] = typeof(OuterGenericStruct<int>),
+            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterGenericStruct(System.Double)"] = typeof(OuterGenericStruct<double>),
+            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterGenericStruct2(System.Int32,System.String)"] = typeof(OuterGenericStruct2<int, string>),
 
-            // Nested types
-            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterContainer+NestedClass"] = typeof(OuterContainer.NestedClass),
-            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterContainer+NestedStruct"] = typeof(OuterContainer.NestedStruct),
-            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterContainer+NestedAbstractClass"] = typeof(OuterContainer.NestedAbstractClass),
-            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterContainer+NestedSealedClass"] = typeof(OuterContainer.NestedSealedClass),
+            // Nested types ('+' -> '-')
+            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterContainer-NestedClass"] = typeof(OuterContainer.NestedClass),
+            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterContainer-NestedStruct"] = typeof(OuterContainer.NestedStruct),
+            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterContainer-NestedAbstractClass"] = typeof(OuterContainer.NestedAbstractClass),
+            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterContainer-NestedSealedClass"] = typeof(OuterContainer.NestedSealedClass),
 
             // Nested generic types
-            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterContainer+NestedGenericClass<System.Int32>"] = typeof(OuterContainer.NestedGenericClass<int>),
-            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterContainer+NestedGenericStruct<System.String>"] = typeof(OuterContainer.NestedGenericStruct<string>),
+            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterContainer-NestedGenericClass(System.Int32)"] = typeof(OuterContainer.NestedGenericClass<int>),
+            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterContainer-NestedGenericStruct(System.String)"] = typeof(OuterContainer.NestedGenericStruct<string>),
 
             // Double nested types
-            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterContainer+NestedContainer+DoubleNestedClass"] = typeof(OuterContainer.NestedContainer.DoubleNestedClass),
-            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterContainer+NestedContainer+DoubleNestedStruct"] = typeof(OuterContainer.NestedContainer.DoubleNestedStruct),
-            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterContainer+NestedContainer+DoubleNestedGenericClass<System.Int32>"] = typeof(OuterContainer.NestedContainer.DoubleNestedGenericClass<int>),
+            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterContainer-NestedContainer-DoubleNestedClass"] = typeof(OuterContainer.NestedContainer.DoubleNestedClass),
+            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterContainer-NestedContainer-DoubleNestedStruct"] = typeof(OuterContainer.NestedContainer.DoubleNestedStruct),
+            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterContainer-NestedContainer-DoubleNestedGenericClass(System.Int32)"] = typeof(OuterContainer.NestedContainer.DoubleNestedGenericClass<int>),
 
             // Generic container with nested types
-            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterGenericContainer<System.Int32>+NestedInGeneric"] = typeof(OuterGenericContainer<int>.NestedInGeneric),
-            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterGenericContainer<System.String>+NestedStructInGeneric"] = typeof(OuterGenericContainer<string>.NestedStructInGeneric),
-            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterGenericContainer<System.Int32>+NestedGenericInGeneric<System.String>"] = typeof(OuterGenericContainer<int>.NestedGenericInGeneric<string>),
+            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterGenericContainer(System.Int32)-NestedInGeneric"] = typeof(OuterGenericContainer<int>.NestedInGeneric),
+            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterGenericContainer(System.String)-NestedStructInGeneric"] = typeof(OuterGenericContainer<string>.NestedStructInGeneric),
+            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterGenericContainer(System.Int32)-NestedGenericInGeneric(System.String)"] = typeof(OuterGenericContainer<int>.NestedGenericInGeneric<string>),
 
             // Interfaces
             ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.IOuterInterface"] = typeof(IOuterInterface),
-            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.IOuterGenericInterface<System.Int32>"] = typeof(IOuterGenericInterface<int>),
+            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.IOuterGenericInterface(System.Int32)"] = typeof(IOuterGenericInterface<int>),
 
             // Enums
             ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterEnum"] = typeof(OuterEnum),
             ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterFlagsEnum"] = typeof(OuterFlagsEnum),
-            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterEnumContainer+NestedEnum"] = typeof(OuterEnumContainer.NestedEnum),
+            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterEnumContainer-NestedEnum"] = typeof(OuterEnumContainer.NestedEnum),
 
             // Existing types from OuterAssembly
             ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.Person"] = typeof(Person),
             ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.Address"] = typeof(Address),
             ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.Company"] = typeof(Company),
             ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.ParentClass"] = typeof(ParentClass),
-            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.ParentClass+NestedClass"] = typeof(ParentClass.NestedClass),
-            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.ParentClass+NestedStaticClass"] = typeof(ParentClass.NestedStaticClass),
-            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.StaticParentClass+NestedClass"] = typeof(StaticParentClass.NestedClass),
-            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.StaticParentClass+NestedStaticClass"] = typeof(StaticParentClass.NestedStaticClass),
-            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.WrapperClass<System.Int32>"] = typeof(WrapperClass<int>),
-            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.WrapperClass<System.String>"] = typeof(WrapperClass<string>),
+            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.ParentClass-NestedClass"] = typeof(ParentClass.NestedClass),
+            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.ParentClass-NestedStaticClass"] = typeof(ParentClass.NestedStaticClass),
+            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.StaticParentClass-NestedClass"] = typeof(StaticParentClass.NestedClass),
+            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.StaticParentClass-NestedStaticClass"] = typeof(StaticParentClass.NestedStaticClass),
+            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.WrapperClass(System.Int32)"] = typeof(WrapperClass<int>),
+            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.WrapperClass(System.String)"] = typeof(WrapperClass<string>),
         };
 
         #endregion
@@ -353,18 +356,18 @@ namespace com.IvanMurzak.ReflectorNet.Tests.TypeUtilsTests
         public static readonly Dictionary<string, Type> OuterAssemblyArrayTypes = new Dictionary<string, Type>
         {
             // Simple arrays
-            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterSimpleClass[]"] = typeof(OuterSimpleClass[]),
-            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterSimpleStruct[]"] = typeof(OuterSimpleStruct[]),
-            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterEnum[]"] = typeof(OuterEnum[]),
+            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterSimpleClass-1"] = typeof(OuterSimpleClass[]),
+            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterSimpleStruct-1"] = typeof(OuterSimpleStruct[]),
+            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterEnum-1"] = typeof(OuterEnum[]),
 
             // Jagged arrays
-            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterSimpleClass[][]"] = typeof(OuterSimpleClass[][]),
+            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterSimpleClass-1-1"] = typeof(OuterSimpleClass[][]),
 
             // Generic arrays
-            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterGenericClass<System.Int32>[]"] = typeof(OuterGenericClass<int>[]),
+            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterGenericClass(System.Int32)-1"] = typeof(OuterGenericClass<int>[]),
 
             // Nested type arrays
-            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterContainer+NestedClass[]"] = typeof(OuterContainer.NestedClass[]),
+            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterContainer-NestedClass-1"] = typeof(OuterContainer.NestedClass[]),
         };
 
         #endregion
@@ -377,33 +380,33 @@ namespace com.IvanMurzak.ReflectorNet.Tests.TypeUtilsTests
         public static readonly Dictionary<string, Type> ComplexCombinedTypes = new Dictionary<string, Type>
         {
             // Generic with outer assembly type
-            ["System.Collections.Generic.List<com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterSimpleClass>"] = typeof(List<OuterSimpleClass>),
-            ["System.Collections.Generic.Dictionary<System.String,com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterSimpleClass>"] = typeof(Dictionary<string, OuterSimpleClass>),
+            ["System.Collections.Generic.List(com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterSimpleClass)"] = typeof(List<OuterSimpleClass>),
+            ["System.Collections.Generic.Dictionary(System.String,com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterSimpleClass)"] = typeof(Dictionary<string, OuterSimpleClass>),
 
             // Generic with nested type
-            ["System.Collections.Generic.List<com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterContainer+NestedClass>"] = typeof(List<OuterContainer.NestedClass>),
+            ["System.Collections.Generic.List(com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterContainer-NestedClass)"] = typeof(List<OuterContainer.NestedClass>),
 
             // Dictionary with two custom types
-            ["System.Collections.Generic.Dictionary<com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterEnum,com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterSimpleClass>"] = typeof(Dictionary<OuterEnum, OuterSimpleClass>),
+            ["System.Collections.Generic.Dictionary(com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterEnum,com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterSimpleClass)"] = typeof(Dictionary<OuterEnum, OuterSimpleClass>),
 
             // Nested generic with outer assembly types
-            ["System.Collections.Generic.List<System.Collections.Generic.Dictionary<System.String,com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterSimpleClass>>"] = typeof(List<Dictionary<string, OuterSimpleClass>>),
+            ["System.Collections.Generic.List(System.Collections.Generic.Dictionary(System.String,com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterSimpleClass))"] = typeof(List<Dictionary<string, OuterSimpleClass>>),
 
             // Generic with generic type argument from outer assembly
-            ["System.Collections.Generic.List<com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterGenericClass<System.Int32>>"] = typeof(List<OuterGenericClass<int>>),
+            ["System.Collections.Generic.List(com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterGenericClass(System.Int32))"] = typeof(List<OuterGenericClass<int>>),
 
             // Array of generic outer assembly type
-            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterGenericClass<System.String>[]"] = typeof(OuterGenericClass<string>[]),
+            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterGenericClass(System.String)-1"] = typeof(OuterGenericClass<string>[]),
 
             // Generic with array type argument
-            ["System.Collections.Generic.List<com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterSimpleClass[]>"] = typeof(List<OuterSimpleClass[]>),
+            ["System.Collections.Generic.List(com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterSimpleClass-1)"] = typeof(List<OuterSimpleClass[]>),
 
             // Dictionary with array value type
-            ["System.Collections.Generic.Dictionary<System.String,com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterSimpleStruct[]>"] = typeof(Dictionary<string, OuterSimpleStruct[]>),
+            ["System.Collections.Generic.Dictionary(System.String,com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterSimpleStruct-1)"] = typeof(Dictionary<string, OuterSimpleStruct[]>),
 
             // Cross-assembly generic combinations
-            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterGenericClass<com.IvanMurzak.ReflectorNet.Tests.Model.Vector3>"] = typeof(OuterGenericClass<Vector3>),
-            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterGenericClass2<com.IvanMurzak.ReflectorNet.Tests.Model.Vector3,com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterSimpleClass>"] = typeof(OuterGenericClass2<Vector3, OuterSimpleClass>),
+            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterGenericClass(com.IvanMurzak.ReflectorNet.Tests.Model.Vector3)"] = typeof(OuterGenericClass<Vector3>),
+            ["com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterGenericClass2(com.IvanMurzak.ReflectorNet.Tests.Model.Vector3,com.IvanMurzak.ReflectorNet.OuterAssembly.Model.OuterSimpleClass)"] = typeof(OuterGenericClass2<Vector3, OuterSimpleClass>),
         };
 
         #endregion

--- a/ReflectorNet.Tests/src/TypeUtilsTests/GetTypeShortNameTests.cs
+++ b/ReflectorNet.Tests/src/TypeUtilsTests/GetTypeShortNameTests.cs
@@ -61,7 +61,12 @@ namespace com.IvanMurzak.ReflectorNet.Tests.TypeUtilsTests
                 var typeId = kvp.Key;
                 var type = kvp.Value;
 
-                var expectedShortName = StripNamespace(typeId);
+                // The shared GetTypeIdTests dictionary keys are firewall-safe schema type-ids
+                // (issue #80): generic '()', nested-class '-', array '-rank'. GetTypeShortName is a
+                // human-readable display name that is intentionally NOT firewall-safe — it still
+                // uses '<>', '+', '[]'/'[, ]'. Convert the safe-form key to that display form before
+                // stripping namespaces so the two representations line up.
+                var expectedShortName = StripNamespace(ToDisplayForm(typeId));
                 var actualShortName = TypeUtils.GetTypeShortName(type);
 
                 // Normalize spaces in expectedShortName just in case
@@ -85,6 +90,96 @@ namespace com.IvanMurzak.ReflectorNet.Tests.TypeUtilsTests
             {
                 Assert.Fail($"Failed {failed.Count} types. See output for details.");
             }
+        }
+
+        /// <summary>
+        /// Converts a firewall-safe schema type-id (issue #80) to the human-readable display form
+        /// that <see cref="TypeUtils.GetTypeShortName"/> emits: generic '(' ')' -> '&lt;' '&gt;',
+        /// nested-class '-&lt;ident&gt;' -> '+', array '-&lt;rank&gt;' -> '[' + (rank-1 commas) + ']'.
+        /// Comma spacing is left to <see cref="StripNamespace"/>, which already inserts a space
+        /// after every comma. Hyphens past a top-level comma (assembly name) are left literal.
+        /// </summary>
+        private string ToDisplayForm(string typeId)
+        {
+            if (string.IsNullOrEmpty(typeId))
+                return typeId;
+
+            var sb = new StringBuilder(typeId.Length + 4);
+            var depth = 0;
+            var inAssemblyName = false;
+
+            for (int i = 0; i < typeId.Length; i++)
+            {
+                var c = typeId[i];
+
+                if (inAssemblyName)
+                {
+                    sb.Append(c);
+                    continue;
+                }
+
+                switch (c)
+                {
+                    case '(':
+                        depth++;
+                        sb.Append('<');
+                        break;
+                    case ')':
+                        depth--;
+                        sb.Append('>');
+                        break;
+                    case '[':
+                        depth++;
+                        sb.Append('[');
+                        break;
+                    case ']':
+                        depth--;
+                        sb.Append(']');
+                        break;
+                    case ',':
+                        if (depth == 0)
+                            inAssemblyName = true;
+                        sb.Append(',');
+                        break;
+                    case '-':
+                        {
+                            var next = i + 1 < typeId.Length ? typeId[i + 1] : '\0';
+                            if (next >= '0' && next <= '9')
+                            {
+                                int j = i + 1;
+                                while (j < typeId.Length && typeId[j] >= '0' && typeId[j] <= '9')
+                                    j++;
+                                var rankText = typeId.Substring(i + 1, j - (i + 1));
+                                if (int.TryParse(rankText, out var rank) && rank >= 1)
+                                {
+                                    sb.Append('[');
+                                    if (rank > 1)
+                                        sb.Append(new string(',', rank - 1));
+                                    sb.Append(']');
+                                    i = j - 1;
+                                }
+                                else
+                                {
+                                    sb.Append('-');
+                                }
+                            }
+                            else if (next == '_' || char.IsLetter(next))
+                            {
+                                sb.Append('+');
+                            }
+                            else
+                            {
+                                sb.Append('-');
+                            }
+                            break;
+                        }
+                    default:
+                        sb.Append(c);
+                        break;
+                }
+            }
+
+            return sb.ToString();
         }
 
         private string StripNamespace(string typeId)

--- a/ReflectorNet/src/Utils/Json/JsonSchema.cs
+++ b/ReflectorNet/src/Utils/Json/JsonSchema.cs
@@ -282,13 +282,13 @@ namespace com.IvanMurzak.ReflectorNet.Utils
                 else
                 {
                     var typeId = type.GetSchemaTypeId();
-                    // The $defs key is stored raw (it's an arbitrary JSON object key). The $ref
-                    // value is a URI reference per JSON Schema, so the type-id fragment must be
-                    // percent-encoded for chars not allowed in URI fragments. A consumer decoding
-                    // the $ref recovers the raw type-id and looks it up in $defs directly.
+                    // The type-id is already firewall-safe (issue #80): its structural delimiters
+                    // ( ( ) - . , ) are all legal unescaped in a URI fragment, so no encoding is
+                    // needed. Emitting it raw keeps the $defs key (stored raw) byte-identical to
+                    // the $ref value — symmetric, no encode/decode asymmetry.
                     schema = new JsonObject
                     {
-                        [Ref] = RefValue + EncodeForJsonSchemaRef(typeId)
+                        [Ref] = RefValue + typeId
                     };
                 }
 
@@ -319,21 +319,6 @@ namespace com.IvanMurzak.ReflectorNet.Utils
                 };
             }
             return schema;
-        }
-
-        /// <summary>
-        /// Percent-encodes characters that are not allowed in a JSON Schema $ref URI fragment.
-        /// $defs keys are raw JSON object keys (e.g. <c>List&lt;int&gt;</c>, <c>Outer+Nested</c>);
-        /// the $ref value is a URI reference per JSON Schema and must escape <c>[ ] &lt; &gt; +</c>.
-        /// A consumer that URI-decodes the fragment recovers the raw type-id stored in $defs.
-        /// </summary>
-        static string EncodeForJsonSchemaRef(string typeId)
-        {
-            if (string.IsNullOrEmpty(typeId))
-                return typeId;
-            return typeId.Replace("[", "%5B").Replace("]", "%5D")
-                         .Replace("<", "%3C").Replace(">", "%3E")
-                         .Replace("+", "%2B");
         }
 
         /// <summary>

--- a/ReflectorNet/src/Utils/TypeUtils.GetType.cs
+++ b/ReflectorNet/src/Utils/TypeUtils.GetType.cs
@@ -7,26 +7,131 @@ namespace com.IvanMurzak.ReflectorNet.Utils
     public static partial class TypeUtils
     {
         /// <summary>
-        /// Decodes percent-encoded type-id chars produced by JSON Schema $ref values
-        /// (<c>%2B %3C %3E %5B %5D</c>) back to their literal forms (<c>+ &lt; &gt; [ ]</c>).
-        /// Callers may submit type names in either raw or $ref-encoded form; normalizing here
-        /// lets every resolution path (cache lookup, Type.GetType, generic/array parsers) see a
-        /// single canonical form. Other percent sequences are left untouched (C# identifiers
-        /// never legitimately contain <c>%</c>, but we preserve the input rather than guess).
+        /// Converts a firewall-safe schema type-id (issue #80) into the C#-canonical form that the
+        /// <c>TryResolveArrayType</c> / <c>TryResolveCSharpGenericType</c> / <c>TryResolveClassicGenericType</c>
+        /// parsers expect. The safe form uses delimiters that are illegal in C# identifiers, legal
+        /// unescaped in a URI fragment, and absent from every LLM provider's content-firewall blocklist:
+        /// <list type="bullet">
+        /// <item><c>(</c> -> <c>&lt;</c> and <c>)</c> -> <c>&gt;</c> (generic args)</item>
+        /// <item><c>-&lt;digits&gt;</c> -> <c>[</c> + (rank-1 commas) + <c>]</c> (array rank: <c>-1</c> -> <c>[]</c>, <c>-2</c> -> <c>[,]</c>, jagged <c>-1-1</c> -> <c>[][]</c>)</item>
+        /// <item><c>-&lt;letter|underscore&gt;</c> -> <c>+</c> (nested class)</item>
+        /// </list>
+        /// Disambiguation is unambiguous because C# identifiers cannot start with a digit: a digit
+        /// after <c>-</c> is always an array rank, a letter/underscore is always a nested class.
+        /// <para>
+        /// Callers may submit either the safe form (e.g. <c>System.Int32-1</c>, what a JSON Schema
+        /// <c>$ref</c> consumer round-trips) or the already-canonical raw form (e.g. <c>System.Int32[]</c>);
+        /// both normalize to canonical here so every resolution path sees a single form.
+        /// </para>
+        /// <para>
+        /// Assembly-qualified-name edge: an assembly name can legitimately contain a hyphen
+        /// (e.g. <c>Some-Assembly</c>). Only hyphens inside the TYPE-NAME portion are structural;
+        /// once the scan crosses the first top-level (bracket-depth 0) comma — which introduces the
+        /// assembly name — hyphens are left literal. Hyphens inside an existing <c>[ ]</c> classic-AQN
+        /// region (depth &gt; 0) are likewise left untouched.
+        /// </para>
         /// </summary>
         static string DecodeSchemaRefChars(string typeName)
         {
-            if (typeName.IndexOf('%') < 0)
+            if (string.IsNullOrEmpty(typeName))
                 return typeName;
-            return typeName.Replace("%5B", "[").Replace("%5D", "]")
-                           .Replace("%3C", "<").Replace("%3E", ">")
-                           .Replace("%2B", "+");
+
+            // Fast path: nothing structural to convert.
+            if (typeName.IndexOf('(') < 0 && typeName.IndexOf(')') < 0 && typeName.IndexOf('-') < 0)
+                return typeName;
+
+            var sb = new System.Text.StringBuilder(typeName.Length + 4);
+            var depth = 0;            // nesting depth across generic '(' and classic-AQN '['.
+            var inAssemblyName = false; // set once a top-level (depth-0) comma is crossed.
+
+            for (int i = 0; i < typeName.Length; i++)
+            {
+                var c = typeName[i];
+
+                if (inAssemblyName)
+                {
+                    // Past the type-name portion: emit verbatim, but still translate generic
+                    // close brackets that wrap the whole AQN-bearing argument list is not expected
+                    // for safe-form ids, so just copy through.
+                    sb.Append(c);
+                    continue;
+                }
+
+                switch (c)
+                {
+                    case '(':
+                        depth++;
+                        sb.Append('<');
+                        break;
+                    case ')':
+                        depth--;
+                        sb.Append('>');
+                        break;
+                    case '[':
+                        // Already-canonical bracket (raw input or classic AQN). Track depth so a
+                        // depth>0 comma is not mistaken for the assembly separator.
+                        depth++;
+                        sb.Append('[');
+                        break;
+                    case ']':
+                        depth--;
+                        sb.Append(']');
+                        break;
+                    case ',':
+                        if (depth == 0)
+                            inAssemblyName = true; // assembly name begins; stop structural decoding.
+                        sb.Append(',');
+                        break;
+                    case '-':
+                        {
+                            var next = i + 1 < typeName.Length ? typeName[i + 1] : '\0';
+                            if (next >= '0' && next <= '9')
+                            {
+                                // Array rank: read all consecutive digits.
+                                int j = i + 1;
+                                while (j < typeName.Length && typeName[j] >= '0' && typeName[j] <= '9')
+                                    j++;
+                                var rankText = typeName.Substring(i + 1, j - (i + 1));
+                                // Defensive: int.Parse on a bounded digit run.
+                                if (int.TryParse(rankText, out var rank) && rank >= 1)
+                                {
+                                    sb.Append('[');
+                                    if (rank > 1)
+                                        sb.Append(new string(',', rank - 1));
+                                    sb.Append(']');
+                                    i = j - 1; // skip the consumed digits.
+                                }
+                                else
+                                {
+                                    sb.Append('-'); // not a valid rank; leave literal.
+                                }
+                            }
+                            else if (next == '_' || char.IsLetter(next))
+                            {
+                                // Nested class.
+                                sb.Append('+');
+                            }
+                            else
+                            {
+                                // Hyphen not introducing a rank or nested class (e.g. a stray
+                                // hyphen). Leave literal.
+                                sb.Append('-');
+                            }
+                            break;
+                        }
+                    default:
+                        sb.Append(c);
+                        break;
+                }
+            }
+
+            return sb.ToString();
         }
 
         /// <summary>
         /// Retrieves a <see cref="Type"/> by its name.
         /// </summary>
-        /// <param name="typeName">The name of the type to retrieve. Can be a full name, assembly qualified name, or a custom identifier. Percent-encoded chars <c>%2B %3C %3E %5B %5D</c> are decoded before resolution so $ref-style input is accepted alongside raw type ids.</param>
+        /// <param name="typeName">The name of the type to retrieve. Can be a full name, assembly qualified name, or a custom identifier. Firewall-safe schema type-ids (issue #80; e.g. <c>System.Int32-1</c>, <c>IList(System.Int32)</c>, <c>Outer-Nested</c>) are converted to their C#-canonical form before resolution, so $ref-style input is accepted alongside raw type ids.</param>
         /// <returns>The <see cref="Type"/> corresponding to the specified name, or <see langword="null"/> if the type cannot be found.</returns>
         public static Type? GetType(string? typeName)
         {
@@ -80,7 +185,10 @@ namespace com.IvanMurzak.ReflectorNet.Utils
             type = AssemblyUtils.AllTypes.FirstOrDefault(t =>
                 typeName == t.FullName ||
                 typeName == t.AssemblyQualifiedName ||
-                typeName == t.GetTypeId());
+                // typeName has already been normalized to canonical form by DecodeSchemaRefChars;
+                // GetTypeId() now emits the firewall-safe form (issue #80), so decode it too before
+                // comparing (covers open generics / nested types where no parser path matched).
+                typeName == DecodeSchemaRefChars(t.GetTypeId()));
 
             _typeCache[typeName] = type;
 
@@ -157,7 +265,7 @@ namespace com.IvanMurzak.ReflectorNet.Utils
             type = AssemblyUtils.GetTypesStartingWith(assemblyName).FirstOrDefault(t =>
                 typeName == t.FullName ||
                 typeName == t.AssemblyQualifiedName ||
-                typeName == t.GetTypeId());
+                typeName == DecodeSchemaRefChars(t.GetTypeId()));
 
             _assemblyTypeCache[cacheKey] = type;
 
@@ -221,7 +329,7 @@ namespace com.IvanMurzak.ReflectorNet.Utils
             type = AssemblyUtils.GetAssemblyTypes(assembly).FirstOrDefault(t =>
                 typeName == t.FullName ||
                 typeName == t.AssemblyQualifiedName ||
-                typeName == t.GetTypeId());
+                typeName == DecodeSchemaRefChars(t.GetTypeId()));
 
             _exactAssemblyTypeCache[cacheKey] = type;
 

--- a/ReflectorNet/src/Utils/TypeUtils.GetType.cs
+++ b/ReflectorNet/src/Utils/TypeUtils.GetType.cs
@@ -50,9 +50,9 @@ namespace com.IvanMurzak.ReflectorNet.Utils
 
                 if (inAssemblyName)
                 {
-                    // Past the type-name portion: emit verbatim, but still translate generic
-                    // close brackets that wrap the whole AQN-bearing argument list is not expected
-                    // for safe-form ids, so just copy through.
+                    // Past the type-name portion (a top-level comma introduced the assembly name):
+                    // safe-form ids never carry structural delimiters here, so emit every remaining
+                    // character verbatim without decoding.
                     sb.Append(c);
                     continue;
                 }

--- a/ReflectorNet/src/Utils/TypeUtils.Name.cs
+++ b/ReflectorNet/src/Utils/TypeUtils.Name.cs
@@ -75,11 +75,14 @@ namespace com.IvanMurzak.ReflectorNet.Utils
                         if (totalArgs.Length > outerArgsCount)
                         {
                             var localArgs = totalArgs.Skip(outerArgsCount).Select(GetTypeId);
-                            return $"{declaringTypeId}+{name}<{string.Join(",", localArgs)}>";
+                            // Firewall-safe structural delimiters (issue #80): nested-class '+' -> '-',
+                            // generic '<>' -> '()'. These are illegal in C# identifiers (collision-proof),
+                            // legal unescaped in URI fragments, and absent from every LLM firewall blocklist.
+                            return $"{declaringTypeId}-{name}({string.Join(",", localArgs)})";
                         }
                     }
 
-                    return $"{declaringTypeId}+{name}";
+                    return $"{declaringTypeId}-{name}";
                 }
             }
 
@@ -94,9 +97,10 @@ namespace com.IvanMurzak.ReflectorNet.Utils
                 if (tickIndex > 0)
                     genericTypeName = genericTypeName.Substring(0, tickIndex);
 
-                // Recursively get the type ID for each generic argument
+                // Recursively get the type ID for each generic argument.
+                // Firewall-safe generic delimiters (issue #80): '<>' -> '()'.
                 var genericArgs = type.GetGenericArguments().Select(GetTypeId);
-                return $"{genericTypeName}<{string.Join(",", genericArgs)}>";
+                return $"{genericTypeName}({string.Join(",", genericArgs)})";
             }
 
             if (type.IsArray)
@@ -105,11 +109,12 @@ namespace com.IvanMurzak.ReflectorNet.Utils
                 if (elementType == null)
                     throw new InvalidOperationException($"Array type '{type}' has no element type.");
 
+                // Firewall-safe array delimiters (issue #80): '[]'/'[,]' -> '-<rank>'.
+                // rank-1 -> '-1', rank-N -> '-N'; jagged repeats stack (int[][] -> '...-1-1').
+                // A digit after '-' denotes array rank; a letter/underscore denotes a nested class.
+                // Since C# identifiers cannot start with a digit, this is unambiguous.
                 var rank = type.GetArrayRank();
-                if (rank == 1)
-                    return $"{GetTypeId(elementType)}{ArraySuffix}";
-
-                return $"{GetTypeId(elementType)}[{new string(',', rank - 1)}]";
+                return $"{GetTypeId(elementType)}-{rank}";
             }
 
             return Sanitize(type);


### PR DESCRIPTION
## Summary

- Re-encodes the JSON Schema type identifiers ReflectorNet emits for MCP tool inputs (`$defs` keys / `$ref` values) so they use delimiters that are simultaneously **illegal in C# identifiers**, **legal unescaped in a URI fragment**, and **absent from both the OpenAI and Google Gemini content-firewall blocklists**.
- **Supersedes the percent-encoding from the already-merged PR #77.** PR #77 percent-encoded `[ ] < > +` in the `$ref` values (`%5B`, `%3C`, …), which fixed OpenAI but broke Google Gemini (Gemini's firewall rejects `%`) — see Unity-MCP issue #780. The two providers have disjoint blocklists, and PR #77 also left raw `< > [ ] +` in the `$defs` keys (asymmetric schema). This PR drops escaping entirely and re-derives the type-id with safe delimiters, so the same schema satisfies Anthropic, Gemini, and OpenAI strict-structured-output, and the `$defs` key is byte-identical to the `$ref` value.

### Delimiter mapping
| C# structural | old (`<5.x` / PR #77 `$ref`) | new (firewall-safe) |
|---|---|---|
| generic `<` `>` | `<` `>` / `%3C` `%3E` | `(` `)` |
| nested-class `+` | `+` / `%2B` | `-` |
| array rank-1 `[]` | `[]` / `%5B%5D` | `-1` |
| array rank-N | `[,]`… / `%5B,%5D`… | `-N` |
| jagged `int[][]` | `[][]` | `-1-1` |
| namespace `.`, generic-arg `,` | unchanged | unchanged |

Disambiguation: after `-`, a digit denotes array rank and a letter/underscore denotes a nested class. Since C# identifiers cannot start with a digit, this is unambiguous in every nesting order.

### Files
- `ReflectorNet/src/Utils/TypeUtils.Name.cs` — `GetTypeId`: the four structural format strings emit `( )`, `-`, `-<rank>`.
- `ReflectorNet/src/Utils/Json/JsonSchema.cs` — `GetSchemaRef`: dropped `EncodeForJsonSchemaRef`; emits `[Ref] = RefValue + typeId` raw (key == ref).
- `ReflectorNet/src/Utils/TypeUtils.GetType.cs` — replaced the percent-decoder with a safe-form → C#-canonical converter run at the top of each `GetType` overload (so the existing array/generic parsers are unchanged); decodes `GetTypeId()` in the resolution fallbacks so open-generic / nested-type round-trips still resolve. Hyphens in the assembly-qualified-name portion are left literal.
- Tests: `TestSchemaTypeId`, `TestSchemaRefEncoding` (now asserts `$defs` keys AND `$ref` values contain none of `< > [ ] + %`), `TestGetTypeDecodeSchemaRef` (raw + safe-form round-trip incl. combo `IList<Outer+Nested[]>`), plus the coupled `TestTypeId`, `GetTypeIdTests`, `GetTypeShortNameTests`.

## Test plan
- [x] Suite 1 — ReflectorNet xUnit: **1445/1445 pass on net8.0 AND net9.0**.
- [x] Suite 2 — MCP-Plugin-dotnet consumer: compiles against a local-packed dev build; `McpPlugin.Server.Tests` **268/268 pass** on both TFMs.
- [x] Suite 3 — Unity-MCP EditMode: **946/946 pass**.

## Known / intended downstream break
3 `MCP-Plugin-dotnet` tests fail (`McpBuilderTests_ListTool.ListTool_NoArgsListOfIntReturnMethod`, `ListTool_NoArgsListOfGenericReturnMethod`, `ListTool_GenericMethodWithComplexType`) because their expected-schema fixtures (`McpPlugin.Tests/Utils/JsonObjectBuilder.cs`) hard-code the old `%`-encoding. This is the **intended** supersession of PR #77 and is **tracked for the ReflectorNet release + MCP-Plugin-dotnet consumer upgrade** (separate task) — not fixed in this PR (the consumer is a downstream verifier here).

## Related
- Supersedes ReflectorNet PR #77 (percent-encoding)
- Unity-MCP issue #780 (Gemini-CLI tool calls broken)
- ReflectorNet issue #668

Closes #80