### PR TITLE
feat: accept JSON object or stringified-JSON for stringified-blob string params

### DIFF
--- a/ReflectorNet.Tests/src/SchemaTests/JsonStringOrObjectTests.cs
+++ b/ReflectorNet.Tests/src/SchemaTests/JsonStringOrObjectTests.cs
@@ -1,0 +1,228 @@
+/*
+ * ReflectorNet
+ * Author: Ivan Murzak (https://github.com/IvanMurzak)
+ * Copyright (c) 2025 Ivan Murzak
+ * Licensed under the Apache License, Version 2.0. See LICENSE file in the project root for full license information.
+ */
+
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text.Json;
+using System.Threading.Tasks;
+using com.IvanMurzak.ReflectorNet.Json;
+using com.IvanMurzak.ReflectorNet.Utils;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace com.IvanMurzak.ReflectorNet.Tests.SchemaTests
+{
+    /// <summary>
+    /// Covers issue #82: a `string` parameter annotated with [JsonStringOrObject] must
+    /// (1) emit an anyOf[string, object] schema, and the binder must (2) accept a raw JSON
+    /// object/array for ANY `string` parameter by coercing it to its raw JSON text.
+    /// </summary>
+    public class JsonStringOrObjectTests : BaseTest
+    {
+        private readonly Reflector _reflector;
+
+        public JsonStringOrObjectTests(ITestOutputHelper output) : base(output)
+        {
+            _reflector = new Reflector();
+        }
+
+        // Echo methods used by the binder tests.
+        public static string TestAnnotatedStringMethod([JsonStringOrObject] string jsonPatch) => jsonPatch;
+        public static string TestPlainStringMethod(string value) => value;
+
+        #region Schema shape
+
+        [Fact]
+        public void Schema_AnnotatedStringParameter_IsAnyOfStringObject()
+        {
+            // Arrange
+            var methodInfo = typeof(JsonStringOrObjectTests).GetMethod(nameof(TestAnnotatedStringMethod))!;
+
+            // Act
+            var schema = _reflector.GetArgumentsSchema(methodInfo)!;
+            _output.WriteLine(schema.ToString());
+
+            // Assert
+            var paramSchema = schema[JsonSchema.Properties]!["jsonPatch"]!;
+
+            var anyOf = paramSchema[JsonSchema.AnyOf];
+            Assert.NotNull(anyOf);
+
+            var anyOfArray = anyOf!.AsArray();
+            Assert.Equal(2, anyOfArray.Count);
+
+            // One branch is a plain string, the other an object with additionalProperties:true.
+            var hasString = false;
+            var hasObject = false;
+            foreach (var branch in anyOfArray)
+            {
+                var typeValue = branch![JsonSchema.Type]?.ToString();
+                if (typeValue == JsonSchema.String)
+                    hasString = true;
+                if (typeValue == JsonSchema.Object)
+                {
+                    hasObject = true;
+                    Assert.True(branch[JsonSchema.AdditionalProperties]!.GetValue<bool>());
+                }
+            }
+            Assert.True(hasString, "anyOf must contain a {\"type\":\"string\"} branch");
+            Assert.True(hasObject, "anyOf must contain a {\"type\":\"object\"} branch");
+        }
+
+        [Fact]
+        public void Schema_UnannotatedStringParameter_IsFlatString()
+        {
+            // Arrange
+            var methodInfo = typeof(JsonStringOrObjectTests).GetMethod(nameof(TestPlainStringMethod))!;
+
+            // Act
+            var schema = _reflector.GetArgumentsSchema(methodInfo)!;
+            _output.WriteLine(schema.ToString());
+
+            // Assert: un-annotated string stays {"type":"string"} — strictly opt-in, no anyOf.
+            var paramSchema = schema[JsonSchema.Properties]!["value"]!;
+            Assert.Equal(JsonSchema.String, paramSchema[JsonSchema.Type]?.ToString());
+            Assert.Null(paramSchema[JsonSchema.AnyOf]);
+        }
+
+        #endregion
+
+        #region Binder coercion (dict overload — InvokeDict)
+
+        [Fact]
+        public async Task Binder_Dict_ObjectForStringParam_BindsRawJsonText()
+        {
+            // Arrange
+            var methodInfo = typeof(JsonStringOrObjectTests).GetMethod(nameof(TestAnnotatedStringMethod))!;
+            var wrapper = MethodWrapper.Create(_reflector, null, methodInfo!);
+
+            var jsonElement = JsonDocument.Parse("{\"op\":\"add\",\"path\":\"/x\",\"value\":1}").RootElement;
+            Assert.Equal(JsonValueKind.Object, jsonElement.ValueKind);
+            var parameters = new Dictionary<string, object?> { { "jsonPatch", jsonElement } };
+
+            // Act
+            var result = await wrapper.InvokeDict(parameters);
+
+            // Assert: the method receives the equivalent stringified JSON.
+            var resultString = Assert.IsType<string>(result);
+            using var roundTrip = JsonDocument.Parse(resultString);
+            Assert.Equal("add", roundTrip.RootElement.GetProperty("op").GetString());
+            Assert.Equal("/x", roundTrip.RootElement.GetProperty("path").GetString());
+            Assert.Equal(1, roundTrip.RootElement.GetProperty("value").GetInt32());
+        }
+
+        [Fact]
+        public async Task Binder_Dict_ArrayForStringParam_BindsRawJsonText()
+        {
+            // Arrange
+            var methodInfo = typeof(JsonStringOrObjectTests).GetMethod(nameof(TestAnnotatedStringMethod))!;
+            var wrapper = MethodWrapper.Create(_reflector, null, methodInfo!);
+
+            var jsonElement = JsonDocument.Parse("[1,2,3]").RootElement;
+            Assert.Equal(JsonValueKind.Array, jsonElement.ValueKind);
+            var parameters = new Dictionary<string, object?> { { "jsonPatch", jsonElement } };
+
+            // Act
+            var result = await wrapper.InvokeDict(parameters);
+
+            // Assert
+            var resultString = Assert.IsType<string>(result);
+            using var roundTrip = JsonDocument.Parse(resultString);
+            Assert.Equal(JsonValueKind.Array, roundTrip.RootElement.ValueKind);
+            Assert.Equal(3, roundTrip.RootElement.GetArrayLength());
+        }
+
+        [Fact]
+        public async Task Binder_Dict_PlainJsonStringForStringParam_StillAccepted()
+        {
+            // Arrange
+            var methodInfo = typeof(JsonStringOrObjectTests).GetMethod(nameof(TestAnnotatedStringMethod))!;
+            var wrapper = MethodWrapper.Create(_reflector, null, methodInfo!);
+
+            // A plain JSON string value (the existing supported form) must keep working unchanged.
+            var jsonElement = JsonDocument.Parse("\"already-a-string\"").RootElement;
+            Assert.Equal(JsonValueKind.String, jsonElement.ValueKind);
+            var parameters = new Dictionary<string, object?> { { "jsonPatch", jsonElement } };
+
+            // Act
+            var result = await wrapper.InvokeDict(parameters);
+
+            // Assert
+            Assert.Equal("already-a-string", result);
+        }
+
+        [Fact]
+        public async Task Binder_Dict_ObjectForUnannotatedStringParam_AlsoCoerced()
+        {
+            // The binder coercion is unconditional (does NOT require the attribute): a raw object
+            // for a plain `string` param is still coerced to raw JSON text. Only the SCHEMA is opt-in.
+            var methodInfo = typeof(JsonStringOrObjectTests).GetMethod(nameof(TestPlainStringMethod))!;
+            var wrapper = MethodWrapper.Create(_reflector, null, methodInfo!);
+
+            var jsonElement = JsonDocument.Parse("{\"k\":\"v\"}").RootElement;
+            var parameters = new Dictionary<string, object?> { { "value", jsonElement } };
+
+            var result = await wrapper.InvokeDict(parameters);
+
+            var resultString = Assert.IsType<string>(result);
+            using var roundTrip = JsonDocument.Parse(resultString);
+            Assert.Equal("v", roundTrip.RootElement.GetProperty("k").GetString());
+        }
+
+        [Fact]
+        public async Task Binder_Dict_PlainStringForUnannotatedStringParam_Unaffected()
+        {
+            // A normal string value for a normal string param behaves exactly as before.
+            var methodInfo = typeof(JsonStringOrObjectTests).GetMethod(nameof(TestPlainStringMethod))!;
+            var wrapper = MethodWrapper.Create(_reflector, null, methodInfo!);
+
+            var jsonElement = JsonDocument.Parse("\"hello\"").RootElement;
+            var parameters = new Dictionary<string, object?> { { "value", jsonElement } };
+
+            var result = await wrapper.InvokeDict(parameters);
+
+            Assert.Equal("hello", result);
+        }
+
+        #endregion
+
+        #region Binder coercion (params object?[] overload — Invoke)
+
+        [Fact]
+        public async Task Binder_Positional_ObjectForStringParam_BindsRawJsonText()
+        {
+            // Exercises the OTHER GetParameterValue overload (BuildParameters(object?[]) via Invoke).
+            var methodInfo = typeof(JsonStringOrObjectTests).GetMethod(nameof(TestAnnotatedStringMethod))!;
+            var wrapper = MethodWrapper.Create(_reflector, null, methodInfo!);
+
+            var jsonElement = JsonDocument.Parse("{\"op\":\"replace\"}").RootElement;
+
+            // Act
+            var result = await wrapper.Invoke(jsonElement);
+
+            // Assert
+            var resultString = Assert.IsType<string>(result);
+            using var roundTrip = JsonDocument.Parse(resultString);
+            Assert.Equal("replace", roundTrip.RootElement.GetProperty("op").GetString());
+        }
+
+        [Fact]
+        public async Task Binder_Positional_PlainJsonStringForStringParam_StillAccepted()
+        {
+            var methodInfo = typeof(JsonStringOrObjectTests).GetMethod(nameof(TestAnnotatedStringMethod))!;
+            var wrapper = MethodWrapper.Create(_reflector, null, methodInfo!);
+
+            var jsonElement = JsonDocument.Parse("\"plain\"").RootElement;
+
+            var result = await wrapper.Invoke(jsonElement);
+
+            Assert.Equal("plain", result);
+        }
+
+        #endregion
+    }
+}

--- a/ReflectorNet/src/Converter/Json/JsonStringOrObjectAttribute.cs
+++ b/ReflectorNet/src/Converter/Json/JsonStringOrObjectAttribute.cs
@@ -1,0 +1,45 @@
+/*
+ * ReflectorNet
+ * Author: Ivan Murzak (https://github.com/IvanMurzak)
+ * Copyright (c) 2025 Ivan Murzak
+ * Licensed under the Apache License, Version 2.0. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Text.Json.Nodes;
+using com.IvanMurzak.ReflectorNet.Utils;
+
+namespace com.IvanMurzak.ReflectorNet.Json
+{
+    /// <summary>
+    /// Opt-in marker for a <see cref="string"/> parameter whose value carries a "stringified JSON blob"
+    /// (e.g. a <c>jsonPatch</c> argument). By default a <see cref="string"/> parameter emits a flat
+    /// <c>{"type":"string"}</c> input schema, so an LLM that sends the value as a raw JSON object/array
+    /// (instead of a JSON string) is rejected up front by schema validation.
+    ///
+    /// When this attribute is applied to a <see cref="string"/> parameter, the generated schema for that
+    /// parameter becomes an <c>anyOf</c> of string + object so both forms are accepted transparently:
+    /// <code>{"anyOf":[{"type":"string"},{"type":"object","additionalProperties":true}]}</code>
+    ///
+    /// This is strictly opt-in: an un-annotated <see cref="string"/> parameter keeps emitting
+    /// <c>{"type":"string"}</c>. The complementary binder coercion (object/array -&gt; raw JSON text) in
+    /// <see cref="MethodWrapper"/> is unconditional and does not require this attribute.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = true)]
+    public sealed class JsonStringOrObjectAttribute : Attribute
+    {
+        /// <summary>
+        /// The schema emitted for a <see cref="string"/> parameter annotated with this attribute:
+        /// an <c>anyOf</c> accepting either a JSON string or a raw JSON object. Mirrors the
+        /// <c>JsonArrayJsonConverter.JsonAnySchema</c> pattern.
+        /// </summary>
+        public static JsonNode Schema => new JsonObject
+        {
+            [JsonSchema.AnyOf] = new JsonArray
+            {
+                new JsonObject { [JsonSchema.Type] = JsonSchema.String },
+                new JsonObject { [JsonSchema.Type] = JsonSchema.Object, [JsonSchema.AdditionalProperties] = true }
+            }
+        };
+    }
+}

--- a/ReflectorNet/src/Reflector/MethodWrapper.cs
+++ b/ReflectorNet/src/Reflector/MethodWrapper.cs
@@ -264,6 +264,16 @@ namespace com.IvanMurzak.ReflectorNet
             // Handle JsonElement conversion
             if (value is JsonElement jsonElement)
             {
+                // Coerce a raw JSON object/array into its raw JSON text when the target is `string`.
+                // This lets a `string` parameter that carries a "stringified JSON blob" (e.g. jsonPatch)
+                // accept BOTH a JSON string and a raw JSON object/array transparently. Without this,
+                // jsonElement.Deserialize<string>(...) throws on an object/array.
+                if (underlyingType == typeof(string) &&
+                    (jsonElement.ValueKind == JsonValueKind.Object || jsonElement.ValueKind == JsonValueKind.Array))
+                {
+                    return jsonElement.GetRawText();
+                }
+
                 var isPrimitive = TypeUtils.IsPrimitive(underlyingType);
                 if (!isPrimitive)
                 {
@@ -348,6 +358,16 @@ namespace com.IvanMurzak.ReflectorNet
             {
                 if (value is JsonElement jsonElement)
                 {
+                    // Coerce a raw JSON object/array into its raw JSON text when the target is `string`.
+                    // This lets a `string` parameter that carries a "stringified JSON blob" (e.g. jsonPatch)
+                    // accept BOTH a JSON string and a raw JSON object/array transparently. Without this,
+                    // jsonElement.Deserialize<string>(...) throws on an object/array.
+                    if (underlyingType == typeof(string) &&
+                        (jsonElement.ValueKind == JsonValueKind.Object || jsonElement.ValueKind == JsonValueKind.Array))
+                    {
+                        return jsonElement.GetRawText();
+                    }
+
                     var isPrimitive = TypeUtils.IsPrimitive(underlyingType);
                     if (!isPrimitive)
                     {

--- a/ReflectorNet/src/Utils/Json/JsonSchema.cs
+++ b/ReflectorNet/src/Utils/Json/JsonSchema.cs
@@ -431,7 +431,8 @@ namespace com.IvanMurzak.ReflectorNet.Utils
                     type: p.ParameterType,
                     name: p.Name ?? throw new InvalidOperationException($"Parameter in method '{method.Name}' has no name."),
                     description: TypeUtils.GetDescription(p),
-                    required: !p.HasDefaultValue));
+                    required: !p.HasDefaultValue,
+                    attributeProvider: (ICustomAttributeProvider?)p));
 
             return GenerateSchema(reflector, types, justRef, defines);
         }
@@ -534,6 +535,24 @@ namespace com.IvanMurzak.ReflectorNet.Utils
             IEnumerable<(Type type, string name, string? description, bool required)> types,
             bool justRef = false,
             JsonObject? defines = null)
+            => GenerateSchema(
+                reflector,
+                types.Select(t => (t.type, t.name, t.description, t.required, attributeProvider: (ICustomAttributeProvider?)null)),
+                justRef,
+                defines);
+
+        /// <summary>
+        /// Overload of <see cref="GenerateSchema(Reflector, IEnumerable{ValueTuple{Type, string, string, bool}}, bool, JsonObject)"/>
+        /// that additionally carries the originating <see cref="ICustomAttributeProvider"/> (typically a
+        /// <see cref="ParameterInfo"/>) for each entry, so per-member schema attributes such as
+        /// <see cref="com.IvanMurzak.ReflectorNet.Json.JsonStringOrObjectAttribute"/> can be honored during
+        /// schema generation. Entries with a <c>null</c> attribute provider behave exactly as the 4-tuple overload.
+        /// </summary>
+        public JsonNode GenerateSchema(
+            Reflector reflector,
+            IEnumerable<(Type type, string name, string? description, bool required, ICustomAttributeProvider? attributeProvider)> types,
+            bool justRef = false,
+            JsonObject? defines = null)
         {
             var needToAddDefines = defines == null;
             defines ??= new();
@@ -554,7 +573,20 @@ namespace com.IvanMurzak.ReflectorNet.Utils
                 var isPrimitive = TypeUtils.IsPrimitive(parameter.type);
                 if (isPrimitive)
                 {
-                    parameterSchema = GetSchema(reflector, parameter.type, defines: defines);
+                    // Opt-in: a `string` parameter annotated with [JsonStringOrObject] emits an anyOf of
+                    // string + object so callers can pass either a JSON string or a raw JSON object.
+                    if ((Nullable.GetUnderlyingType(parameter.type) ?? parameter.type) == typeof(string) &&
+                        parameter.attributeProvider != null &&
+                        parameter.attributeProvider
+                            .GetCustomAttributes(typeof(com.IvanMurzak.ReflectorNet.Json.JsonStringOrObjectAttribute), inherit: true)
+                            .Length > 0)
+                    {
+                        parameterSchema = com.IvanMurzak.ReflectorNet.Json.JsonStringOrObjectAttribute.Schema;
+                    }
+                    else
+                    {
+                        parameterSchema = GetSchema(reflector, parameter.type, defines: defines);
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
## Summary
- Add opt-in `[JsonStringOrObject]` parameter attribute: applied to a `string` param it makes the emitted schema an `anyOf` of `{"type":"string"}` + `{"type":"object","additionalProperties":true}` (mirrors `JsonArrayJsonConverter.JsonAnySchema`). Strictly opt-in — un-annotated `string` params keep emitting `{"type":"string"}`.
- Unconditional binder coercion in BOTH `MethodWrapper.GetParameterValue` overloads: when the target type is `string` and the incoming `JsonElement` is Object/Array, bind `jsonElement.GetRawText()` instead of `Deserialize<string>` (which threw on objects/arrays).
- Wired through a new attribute-provider-carrying `GenerateSchema` overload so `GetArgumentsSchema` can honor parameter attributes; the existing 4-tuple overload delegates to it with a `null` provider (no public API break).

## Test plan
- [x] ReflectorNet xUnit suite: 1454/1454 green on net8.0 + net9.0 (11 new `JsonStringOrObjectTests`).
- [x] MCP-Plugin-dotnet consumer suite (against locally-packed ReflectorNet): McpPlugin.Tests 409/409 + McpPlugin.Server.Tests 268/268, both TFMs.
- [x] Unity-MCP-Plugin EditMode (against freshly-built ReflectorNet DLL): 953/953 passed.

Closes #82